### PR TITLE
feat: add copy action to rich text previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Live app: https://text-generator-with-variables.netlify.app/
 - Replace simple variables with `{{key}}` placeholders.
 - Expand list variables inside iterable template sections.
 - Define environments for values that change by context.
+- Copy converted rich text previews to the clipboard.
 - Save the current workspace to a JSON file and load it later.
 - Persist active work in browser `localStorage`.
 
@@ -121,6 +122,10 @@ With the Production environment selected, the converted result is:
 Open https://example.com/login
 ```
 
+### Copy Converted Text
+
+Each converted rich text preview includes a **Copy** button. The copy action writes rich text HTML to the clipboard when the browser supports it and falls back to plain text otherwise.
+
 ### Save And Load
 
 Use **Save as** to download the current browser cache as `save_document.json`.
@@ -144,7 +149,7 @@ The saved document contains:
 - `ToolsHeader`: Renders navigation buttons, active environment selector, and global Convert action.
 - `Environments`: Manages environment columns and shared environment keys.
 - `Variable`: Manages a single variable or list variable, including list item ordering.
-- `RichTextPair`: Displays one editable template and its converted preview.
+- `RichTextPair`: Displays one editable template, its converted preview, and the preview copy action.
 - `RichText`: Wraps CKEditor for editor and read-only preview modes.
 - `InstructionsModal`: Shows in-app usage instructions.
 - `TextPair`: Legacy plain textarea implementation that is currently not used by `App`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -148,7 +148,7 @@ The global Convert button runs this conversion for every text/template pair and 
 - `ToolsHeader`: Provides quick navigation, active environment selection, and global conversion.
 - `Environments`: Manages environment names, shared keys, per-environment values, environment creation, key creation, and deletes.
 - `Variable`: Edits single variables and list variables, including list item add/delete/clear/reorder behavior.
-- `RichTextPair`: Connects one `TextResultInterface` to editable and preview rich text editors.
+- `RichTextPair`: Connects one `TextResultInterface` to editable and preview rich text editors, and owns the converted preview copy-to-clipboard action.
 - `RichText`: Configures CKEditor plugins, toolbar, table toolbar, editor mode, and preview mode.
 - `InstructionsModal`: Shows user-facing syntax examples.
 - `TextPair`: Legacy textarea-based template pair component, currently unused.

--- a/src/App.css
+++ b/src/App.css
@@ -130,6 +130,18 @@
     border-color: transparent; /* Reset border for this button */
 }
 
+.rich-text-preview-header {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+    margin-top: 0.75rem;
+}
+
+.rich-text-preview-header button {
+    min-width: 96px;
+}
+
 .rich-text-preview .ck.ck-editor__editable {
     background-color: #fff !important;
 }

--- a/src/components/RichTextPair.tsx
+++ b/src/components/RichTextPair.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { TextResultInterface } from '../common/textResult.interface'
 import { RichText } from './RichText'
 
@@ -9,9 +9,60 @@ interface RichTextPairProps {
 }
 
 export const RichTextPair = (props: RichTextPairProps) => {
+    const [copyStatus, setCopyStatus] = useState<'idle' | 'copied' | 'error'>(
+        'idle',
+    )
+
     useEffect(() => {
         console.log('RichTextPairProps updated: props.info', props.info)
     }, [props.info])
+
+    useEffect(() => {
+        if (copyStatus === 'idle') {
+            return
+        }
+
+        const timeoutId = window.setTimeout(() => {
+            setCopyStatus('idle')
+        }, 2000)
+
+        return () => window.clearTimeout(timeoutId)
+    }, [copyStatus])
+
+    const getPlainText = (html: string) => {
+        const container = document.createElement('div')
+        container.innerHTML = html
+        return container.textContent ?? ''
+    }
+
+    const copyConvertedText = async () => {
+        const html = props.info.converted
+        const plainText = getPlainText(html)
+
+        try {
+            if (
+                navigator.clipboard &&
+                'write' in navigator.clipboard &&
+                typeof ClipboardItem !== 'undefined'
+            ) {
+                await navigator.clipboard.write([
+                    new ClipboardItem({
+                        'text/html': new Blob([html], { type: 'text/html' }),
+                        'text/plain': new Blob([plainText], {
+                            type: 'text/plain',
+                        }),
+                    }),
+                ])
+            } else {
+                await navigator.clipboard.writeText(plainText)
+            }
+
+            setCopyStatus('copied')
+        } catch (error) {
+            console.error('Unable to copy converted text', error)
+            setCopyStatus('error')
+        }
+    }
 
     return (
         <div>
@@ -19,12 +70,26 @@ export const RichTextPair = (props: RichTextPairProps) => {
             <RichText
                 content={props.info.raw}
                 type="editor"
-                onChange={(text: any) => {
+                onChange={(text: string) => {
                     console.log('RichTextPairProps onChange: text', text)
                     props.onUpdateText(text)
                 }}
             />
-            <label>Converted</label>
+            <div className="rich-text-preview-header">
+                <label>Converted</label>
+                <button
+                    type="button"
+                    onClick={copyConvertedText}
+                    disabled={!props.info.converted}
+                    aria-label="Copy converted rich text to clipboard"
+                >
+                    {copyStatus === 'copied'
+                        ? 'Copied'
+                        : copyStatus === 'error'
+                          ? 'Copy failed'
+                          : 'Copy'}
+                </button>
+            </div>
             <RichText
                 content={props.info.converted}
                 type="preview"


### PR DESCRIPTION
## Summary
- Add a Copy button to each converted rich text preview
- Copy rich text HTML with a plain-text fallback
- Document the preview copy behavior in README and architecture notes

## Verification
- npm run build
- npx eslint src/components/RichTextPair.tsx --ext ts,tsx --report-unused-disable-directives --max-warnings 0

Note: Full npm run lint still fails due to pre-existing lint issues outside this change.