### PR TITLE
feat: add file templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Live app: https://text-generator-with-variables.netlify.app/
 - Expand list variables inside iterable template sections.
 - Define environments for values that change by context.
 - Switch each template between edit and converted preview modes.
+- Create file templates that convert XLSX files client-side by replacing spreadsheet placeholders.
 - Copy converted rich text previews to the clipboard.
 - Save the current workspace to a JSON file and load it later.
 - Persist active work in browser `localStorage`.
@@ -131,6 +132,18 @@ Each converted rich text preview includes a **Copy** button. The copy action wri
 
 Templates show either the editable original or the converted preview, never both at the same time. Use a template's **Convert** button to convert only that template and switch it to preview mode. Use the global **Convert** button to convert every template and switch every template to preview mode. Use **Edit** on a preview to return that template to edit mode.
 
+### File Templates
+
+Use **File Templates** to select an `.xlsx` file, choose a download file name, and download a converted workbook. The app reads the workbook in the browser, replaces simple placeholders like `{{name}}` in text cells across all worksheets, and downloads the converted file.
+
+Each file template has a **Download file name** input. The filename can use variables and the active environment, for example:
+
+```text
+report-{{clientName}}-{{environmentName}}
+```
+
+If the filename input is empty, the app downloads `<original-name>-converted.xlsx`. Uploaded spreadsheets are not sent to a server or stored in `localStorage`. XLSX conversion uses the selected environment before replacing variables. List-variable row expansion is only supported in rich text templates, not spreadsheets.
+
 ### Save And Load
 
 Use **Save as** to download the current browser cache as `save_document.json`.
@@ -144,8 +157,11 @@ The saved document contains:
   variables: VariableInterface[]
   textResults: TextResultInterface[]
   environments: EnvironmentInterface[]
+  fileTemplates: FileTemplateInterface[]
 }
 ```
+
+Saved files created before File Templates are still supported. When an old JSON file is opened, the app creates a default File Templates row.
 
 ## Main Components
 
@@ -156,6 +172,8 @@ The saved document contains:
 - `Variable`: Manages a single variable or list variable, including list item ordering.
 - `RichTextPair`: Displays one template in either edit or preview mode, including per-template Convert/Edit/Copy actions.
 - `RichText`: Wraps CKEditor for editor and read-only preview modes.
+- `FileTemplates`: Manages saved XLSX file-template rows.
+- `XlsxTemplateUploader`: Uploads an XLSX file, runs simple placeholder replacement, and downloads a converted workbook.
 - `InstructionsModal`: Shows in-app usage instructions.
 - `TextPair`: Legacy plain textarea implementation that is currently not used by `App`.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,10 +7,12 @@ This document describes the current structure and behavior of the Text Generator
 The app is a Vite + React + TypeScript single-page application.
 
 - `src/main.tsx` mounts the React application.
-- `src/App.tsx` owns the core state, conversion logic, section scrolling, and drag-and-drop ordering.
+- `src/App.tsx` owns the core state, section scrolling, and drag-and-drop ordering.
 - Components receive current data and callback props from `App`; most business behavior stays in `App`.
 - `src/services/cache.service.ts` isolates browser `localStorage` reads and writes.
-- `src/services/files.service.ts` handles JSON download creation.
+- `src/services/files.service.ts` handles browser file downloads.
+- `src/services/template.service.ts` contains shared placeholder conversion rules.
+- `src/services/xlsx.service.ts` handles client-side XLSX read, replacement, and download.
 - CKEditor powers rich text editing and preview through the `RichText` component.
 
 ## Project Structure
@@ -27,21 +29,26 @@ The app is a Vite + React + TypeScript single-page application.
 │   │   └── react.svg
 │   ├── common/
 │   │   ├── environment.interface.ts
+│   │   ├── fileTemplate.interface.ts
 │   │   ├── saveDocument.interface.ts
 │   │   ├── textResult.interface.ts
 │   │   └── variable.interface.ts
 │   ├── components/
 │   │   ├── Environments.tsx
+│   │   ├── FileTemplates.tsx
 │   │   ├── Header.tsx
 │   │   ├── InstructionsModal.tsx
 │   │   ├── RichText.tsx
 │   │   ├── RichTextPair.tsx
 │   │   ├── TextPair.tsx
 │   │   ├── ToolsHeader.tsx
-│   │   └── Variable.tsx
+│   │   ├── Variable.tsx
+│   │   └── XlsxTemplateUploader.tsx
 │   ├── services/
 │   │   ├── cache.service.ts
-│   │   └── files.service.ts
+│   │   ├── files.service.ts
+│   │   ├── template.service.ts
+│   │   └── xlsx.service.ts
 │   ├── App.css
 │   ├── App.tsx
 │   ├── index.css
@@ -98,10 +105,22 @@ interface SaveDocumentInterface {
   variables: VariableInterface[]
   textResults: TextResultInterface[]
   environments: EnvironmentInterface[]
+  fileTemplates: FileTemplateInterface[]
 }
 ```
 
 This is the JSON import/export shape.
+
+`FileTemplateInterface`
+
+```ts
+interface FileTemplateInterface {
+  id: string
+  outputFileNameTemplate: string
+}
+```
+
+File template rows persist output filename templates only. Uploaded XLSX files are never stored in localStorage or saved JSON.
 
 ## State And Persistence Flow
 
@@ -111,6 +130,7 @@ On startup, `App` initializes state from `localStorage`:
 - `textResults` from `getCacheTextResults()`
 - `environments` from `getCacheEnvironments()`
 - `currentEnvironmentId` from `getCacheCurrentEnvironmentId()`
+- `fileTemplates` from `getCacheFileTemplates()`
 
 If no templates exist in cache, `App` creates three empty text/template pairs.
 
@@ -120,14 +140,15 @@ State changes are persisted through React effects:
 - Text changes call `setTextResultsCache`.
 - Environment changes call `setEnvironmentsToCache`.
 - Active environment changes call `setCacheCurrentEnvironmentId`.
+- File template changes call `setFileTemplatesToCache`.
 
 The header export action reads the cached document with `getCacheToDownload()` and downloads it as `save_document.json`.
 
-The header import action parses a selected JSON file, checks for `variables` and `textResults`, falls back to an empty `environments` array when missing, writes the data to cache, and reloads the page.
+The header import action parses a selected JSON file, checks for `variables` and `textResults`, falls back to an empty `environments` array when missing, falls back to one default file-template row when `fileTemplates` is missing, writes the data to cache, and reloads the page.
 
 ## Template Conversion Flow
 
-The conversion logic lives in `App.tsx` in the `convert` function.
+The conversion logic lives in `src/services/template.service.ts`.
 
 1. Resolve the active environment by `currentEnvironmentId`.
 2. Create a resolved copy of variables.
@@ -141,6 +162,19 @@ The conversion logic lives in `App.tsx` in the `convert` function.
 
 An individual template Convert button runs this conversion for that template, stores the generated HTML in `converted`, and switches that template to preview mode. The global Convert button runs this conversion for every text/template pair, stores every generated HTML value in `converted`, and switches every template to preview mode.
 
+## XLSX Conversion Flow
+
+The XLSX uploader lives in the File Templates section and runs entirely in the browser.
+
+1. `FileTemplates` renders persisted file-template rows.
+2. `XlsxTemplateUploader` receives a row's output filename template plus the current variables, environments, and active environment from `App`.
+3. The selected file must have an `.xlsx` name.
+4. `xlsx.service.ts` lazy-loads `exceljs`, reads the workbook from the uploaded file's `ArrayBuffer`, and scans every worksheet.
+5. Text cells run through simple placeholder replacement from `template.service.ts`.
+6. The output filename template resolves variables and `{{environmentName}}`, sanitizes path-unsafe characters, ensures `.xlsx`, and falls back to `<original-name>-converted.xlsx` when empty.
+
+XLSX conversion does not persist the uploaded file. It does not expand list-variable sections or evaluate formulas.
+
 ## Component Responsibilities
 
 - `App`: Coordinates application state, cache sync, conversion, drag-and-drop variable ordering, and section navigation.
@@ -150,6 +184,8 @@ An individual template Convert button runs this conversion for that template, st
 - `Variable`: Edits single variables and list variables, including list item add/delete/clear/reorder behavior.
 - `RichTextPair`: Connects one `TextResultInterface` to either the editable rich text editor or the converted preview, exposes per-template Convert/Edit controls, and owns the converted preview copy-to-clipboard action.
 - `RichText`: Configures CKEditor plugins, toolbar, table toolbar, editor mode, and preview mode.
+- `FileTemplates`: Manages file-template rows and persisted output filename templates.
+- `XlsxTemplateUploader`: Owns XLSX upload state, status messaging, and calls the workbook processing service.
 - `InstructionsModal`: Shows user-facing syntax examples.
 - `TextPair`: Legacy textarea-based template pair component, currently unused.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@ckeditor/ckeditor5-react": "^11.0.1",
         "ckeditor5": "^47.3.0",
+        "exceljs": "^4.4.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -27,482 +28,484 @@
       }
     },
     "node_modules/@ckeditor/ckeditor5-adapter-ckfinder": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-47.3.0.tgz",
-      "integrity": "sha512-I0oE2wuyGSwCirHRj5i+IvBRKUrlmGCP7HMGv7fzXcHS1MW43LV0t9L8PQ/aKQX3gNmiqlfj631y/S7s5nqR8A==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-47.7.2.tgz",
+      "integrity": "sha512-MNn7rqhySTA7hQFZhC3b0JJYIQamirK61oiqiT0MP2U6V8KFIrOD+EBqnfLxEiHdkPhoBKTPsrhsJsZeYWDwrQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-upload": "47.3.0",
-        "ckeditor5": "47.3.0"
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-upload": "47.7.2",
+        "ckeditor5": "47.7.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-alignment": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-47.3.0.tgz",
-      "integrity": "sha512-T01xV7UsS4D1VbyRdWxc68Wl4NN/Ov/4+2EsbjYF7O0UA0pJs8dWZJOZ+yGFJ6p8Aask991eu91vy3r/nq3d+g==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-47.7.2.tgz",
+      "integrity": "sha512-xgPhImg9k3G1PQRcBlUa6Gg37E+LeeFs+J1KTX5y6nsbP7p7zwdzJfmnY7luzqfD0H2Zrg7rXfyFBhoAMMRAhg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-icons": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "ckeditor5": "47.3.0"
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-icons": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "ckeditor5": "47.7.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-autoformat": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-47.3.0.tgz",
-      "integrity": "sha512-1Np63YOsNMddrVHtsAPZUQvVuhMyvmwPwnPO3EHudPPDg8c5p+fbSb7DSUSPCUmkIKS8RJ8tv/3eDpS7y+EEXg==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-47.7.2.tgz",
+      "integrity": "sha512-gWhWaM15bbZNBDga7NQc1r4GWuWYPhghSdo7tzXoVnCjgvxRTiJfj0Hhn0b4Chq/cY7Xmsq8aijErupQS3GIAQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-engine": "47.3.0",
-        "@ckeditor/ckeditor5-heading": "47.3.0",
-        "@ckeditor/ckeditor5-typing": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "ckeditor5": "47.3.0"
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-engine": "47.7.2",
+        "@ckeditor/ckeditor5-heading": "47.7.2",
+        "@ckeditor/ckeditor5-typing": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "ckeditor5": "47.7.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-autosave": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-47.3.0.tgz",
-      "integrity": "sha512-ctYdlBcJ/CPUUcpRzCbCp3oG2HWn8gy7GZUL95C1BIZTH08cLKZgkX0TySSUHygMvVymgvWq3LrmwByWri9AvQ==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-47.7.2.tgz",
+      "integrity": "sha512-rj/oj5cpcOsnLmFXPQ0skl026hZJvnDZ0Lf35JPP076FPY417z64SYaI3Eb/7nTWF3vHRYzjz1WwV04vQFxYOA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "ckeditor5": "47.3.0",
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "ckeditor5": "47.7.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-basic-styles": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-47.3.0.tgz",
-      "integrity": "sha512-KGDZLyhVc+sF9o8XTiupNRdroALhLpfOssWQv8zzyu7Ak2LFYXCrrr3abscbIX2whL/X92sted11ktLaLmgL0w==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-47.7.2.tgz",
+      "integrity": "sha512-aw0948T2z5uIYEEGO0tWEVJYwicXtCKDjrKH0Iov+dxIxySKxvE4E0PIhou5+sAgdPo2KRvMtWIvSBzzNSXH+g==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-icons": "47.3.0",
-        "@ckeditor/ckeditor5-typing": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "ckeditor5": "47.3.0"
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-engine": "47.7.2",
+        "@ckeditor/ckeditor5-icons": "47.7.2",
+        "@ckeditor/ckeditor5-typing": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "ckeditor5": "47.7.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-block-quote": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-47.3.0.tgz",
-      "integrity": "sha512-Ik3buFYNpEYVkI5LnimDbHTOgHAYtkZ2qTwGT47wAvyScgQ9Jx0fcUBA6EjX2EuGr6w/snZfXkI4WsZqrMYp+g==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-47.7.2.tgz",
+      "integrity": "sha512-1kauobVYdj3qyOQNyo4Whj6BmAQuDoXlSAT8paWHOR0U3QfWSta1kmJyHRNcJMKXZou4CG1GYzlHVQIEMKExog==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-enter": "47.3.0",
-        "@ckeditor/ckeditor5-icons": "47.3.0",
-        "@ckeditor/ckeditor5-typing": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "ckeditor5": "47.3.0"
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-enter": "47.7.2",
+        "@ckeditor/ckeditor5-icons": "47.7.2",
+        "@ckeditor/ckeditor5-typing": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "ckeditor5": "47.7.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-bookmark": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-bookmark/-/ckeditor5-bookmark-47.3.0.tgz",
-      "integrity": "sha512-Cn+O/Ayr9zcKk/v9dyP1SXbpFslLGCiinS6Nb8jQOS+pmxb1s32W/ycZBtAg0EYmTMskoVEkpwz6ugogNAzmaw==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-bookmark/-/ckeditor5-bookmark-47.7.2.tgz",
+      "integrity": "sha512-l/WWB21mWmwoWfRDTfRwPxXDA5HIzG8a/lUrd8p6HemdT4sK5WQF56eLUQWddFc13lH+fFmdao1/CN52u/JM6g==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-icons": "47.3.0",
-        "@ckeditor/ckeditor5-link": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "@ckeditor/ckeditor5-widget": "47.3.0",
-        "ckeditor5": "47.3.0"
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-icons": "47.7.2",
+        "@ckeditor/ckeditor5-link": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "@ckeditor/ckeditor5-widget": "47.7.2",
+        "ckeditor5": "47.7.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-ckbox": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-47.3.0.tgz",
-      "integrity": "sha512-SVF3CGH7/DBSrsV/vMFIzyvSPAoD1Qg12A5dS+ySnG46XC8ou9uQXXAfIGzAvwajC8GF3LJf9nG4+vJx3tIE/A==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-47.7.2.tgz",
+      "integrity": "sha512-D6cHgAv3UpM5c8j9jKNG99+HQ0sw4KXPeNavDh39aqT3q7MyUAvLjSipi+f/unXREnkV+Cup8VEduKC7/VXiRA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-cloud-services": "47.3.0",
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-engine": "47.3.0",
-        "@ckeditor/ckeditor5-icons": "47.3.0",
-        "@ckeditor/ckeditor5-image": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-upload": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
+        "@ckeditor/ckeditor5-cloud-services": "47.7.2",
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-engine": "47.7.2",
+        "@ckeditor/ckeditor5-icons": "47.7.2",
+        "@ckeditor/ckeditor5-image": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-upload": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
         "blurhash": "2.0.5",
-        "ckeditor5": "47.3.0",
+        "ckeditor5": "47.7.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-ckfinder": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-47.3.0.tgz",
-      "integrity": "sha512-OIDpmoHsw+ZRbhso3EvnSDEKkXZBgZTq7TQT7+TAg264SWuGB7y6UCKMMoA5OWpuqDJh/Wp8wBubTWqA3OwYmw==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-47.7.2.tgz",
+      "integrity": "sha512-7Ofu+7hDzBsja7AJXECueMzqEvl4tnASGko4zbANWzuE2gji5Frv+C4+MuJ3+Ci5gAOfwNfeL0yuhwzAoL/wRA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-icons": "47.3.0",
-        "@ckeditor/ckeditor5-image": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "ckeditor5": "47.3.0"
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-icons": "47.7.2",
+        "@ckeditor/ckeditor5-image": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "ckeditor5": "47.7.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-clipboard": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-47.3.0.tgz",
-      "integrity": "sha512-fVBBWyWIaLTTUZglvOz+ld0QfQR8yr9TVwgk0XFN90S3UxFiYYkxgDAeef/o51qBhBGotgw8hGYYbY4k4G10mA==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-47.7.2.tgz",
+      "integrity": "sha512-ivksfJi0yLNVz3QKGZ9CrVxtpBDOAMcBw0DWqwT7wQdyEIZjoDyJmKnJ3VRjjqZUT/rjw6g0DnTOg7kCBSCQHg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-engine": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "@ckeditor/ckeditor5-widget": "47.3.0",
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-engine": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "@ckeditor/ckeditor5-widget": "47.7.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-cloud-services": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-47.3.0.tgz",
-      "integrity": "sha512-oFHz/Aavs6IDU6XwQD9NUgssJs3hSv4Vu2Np5rkZIyhabKRJcNma7fwM+gmmvQJupltv0uG/0ldMigjfEqHAQA==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-47.7.2.tgz",
+      "integrity": "sha512-F4Awq0oTZbzsu4EaQ3GnbL0xwNWO9zBqbDmRlZIhrQ4la9wXX/2/S8DWfms3Ra7r3u1s+TvteSzoJUwDVUioUQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "ckeditor5": "47.3.0"
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "ckeditor5": "47.7.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-code-block": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-47.3.0.tgz",
-      "integrity": "sha512-zgzlCFqqJxWRTvuIGl9jJ0KYGZIjsCOYHjj1s3+asXjuskRoSip6yzcPK/LPaQXkUYf9zTGJHQ9tqmiNbRQBiA==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-47.7.2.tgz",
+      "integrity": "sha512-nU+Z6+PJm+u07HVLqAqmsl/fAuiTUC2yf8InXBQ9YnLuwoS2zGdepr82oe9MXCImjcwkV3HraOZ1L4yL4xPXXA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "47.3.0",
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-engine": "47.3.0",
-        "@ckeditor/ckeditor5-enter": "47.3.0",
-        "@ckeditor/ckeditor5-icons": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "ckeditor5": "47.3.0"
+        "@ckeditor/ckeditor5-clipboard": "47.7.2",
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-engine": "47.7.2",
+        "@ckeditor/ckeditor5-enter": "47.7.2",
+        "@ckeditor/ckeditor5-icons": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "ckeditor5": "47.7.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-core": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-47.3.0.tgz",
-      "integrity": "sha512-jLawN3a8yL5lbwG8gZeJihcVKkDgq+rAFeXc+Rd+nw+c5uGCdkc5F7PCRjhw+JOGruXUhNsbiF/4iNv3hUcO/A==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-47.7.2.tgz",
+      "integrity": "sha512-4JtvMuQPQYaINrSzDbtYmj/7ver0sks5pa4ABsBNdC/lfYB0kLL7GqxI5rSNtLprf3hAVLR7uAd4ZFEgKe/iHg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-engine": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "@ckeditor/ckeditor5-watchdog": "47.3.0",
+        "@ckeditor/ckeditor5-engine": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "@ckeditor/ckeditor5-watchdog": "47.7.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-easy-image": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-47.3.0.tgz",
-      "integrity": "sha512-pdQHtLBdkDuY59FzzgyTjS6XM5aJlSUW33sOSfN0I/iROl6LpSr1kHjf6ybJAAWEhSD6B+o6hv4+K+tx184UpA==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-47.7.2.tgz",
+      "integrity": "sha512-gAVUlxQr0PDMcAspvRKqCCFAIUrg8/UYEIGRx77CQ7k+SqjFyx+mhxew3w9up7np1yaHGzIon9otSF8OytbSxw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-cloud-services": "47.3.0",
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-upload": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "ckeditor5": "47.3.0"
+        "@ckeditor/ckeditor5-cloud-services": "47.7.2",
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-upload": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "ckeditor5": "47.7.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-balloon": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-47.3.0.tgz",
-      "integrity": "sha512-8EzuV48gTuqrNd5rt58rp7eWf8B5q1PeRUS2f5fAF6RwDS6HsBDeqmEic8JPxOh+30pvAcR6UiylSYe6S+H9bg==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-47.7.2.tgz",
+      "integrity": "sha512-DeOHFtWCwUSWtmw+lmPvFETGch5wtmoCJjaPMkZxo4cW3ik2Uup5cZCOZ6QU3X6egAP+hGOWyebJ6vS0KkAVVQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-engine": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "ckeditor5": "47.3.0",
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-engine": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "ckeditor5": "47.7.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-classic": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-47.3.0.tgz",
-      "integrity": "sha512-uCA8cr23LSJf8POkg2c403zS+xWjbE8Ucu521PQPcxrTMyTI6rYfjnuZ6vT/qzqAwZrLpiNZucJIQxRDFhLWGQ==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-47.7.2.tgz",
+      "integrity": "sha512-7FzuW+xd0X2H3PP43X/bkE9Iko0Gq9xw8jZ8x3Ze4SG8VCaM2IwwLOdbZ0MVZIKKwU0yswAc9eTnsu9/o3PBaA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-engine": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "ckeditor5": "47.3.0",
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-engine": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "ckeditor5": "47.7.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-decoupled": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-47.3.0.tgz",
-      "integrity": "sha512-G4szgSWluqNG/wv+JQxiZv1lzwUzTxdPZWO/mL8pi3sc69vp30QYT+I4TOTLpfBdISBPkWajn/hfEXJPS1hCXw==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-47.7.2.tgz",
+      "integrity": "sha512-A0FC/Mxtg/IHwuvfT2qN/ETN9EUqXw2v+hY8qi/WluESN7Rd/VXM1qbesKwtugAl0nyrTWGQFbHpp0xOHcjwQg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-engine": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "ckeditor5": "47.3.0",
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-engine": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "ckeditor5": "47.7.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-inline": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-47.3.0.tgz",
-      "integrity": "sha512-ie66wno1gbxNuoqGJ7iSDIz4gydPxJtSE5F9kb3NjfwecQxjj/0yBS+HsbZhqbFFNdJ01KZOtbAxNXQ0r1OW2g==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-47.7.2.tgz",
+      "integrity": "sha512-DfiojMP1jmQKuWJqrf8BlDAI31YeSzUgy6P1lV2RHmpQVpIuJbnJt9J9GtnCRB4Ijq1hXBT4S66OoVtieFuyxA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-engine": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "ckeditor5": "47.3.0",
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-engine": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "ckeditor5": "47.7.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-multi-root": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-47.3.0.tgz",
-      "integrity": "sha512-PRxVNpoo7YiECugo9rPsUmuTL3f2xUwvHSUKh6FvPneQS4oFIdMNJrg/Hhn02sEOe6+ScFIi4X06ryK+/N6zOA==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-47.7.2.tgz",
+      "integrity": "sha512-Wbaj0VSOk2knlQVvTn2Nl5Y25XevYA3D+9NNI4YfNjP0wxXdD+16hRyeH4CwwXkPoNe6CNgJzMRjw3Sqp6nfWQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-engine": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "ckeditor5": "47.3.0",
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-engine": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "ckeditor5": "47.7.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-emoji": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-emoji/-/ckeditor5-emoji-47.3.0.tgz",
-      "integrity": "sha512-3xmB9VKShWmK2x1qZ7BecfqaxAGP6Ys1/UEPhBhoFyRK34UvtA9KrK0G+KWF4kwA5OgkoqnQRmVkMEO6mKXMnw==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-emoji/-/ckeditor5-emoji-47.7.2.tgz",
+      "integrity": "sha512-1bBuLDsEEA45uJvNB566me89UOyIvp5w6VGEchrwPmSJPUEnLHWl7cNfax+uxMK0+pn5rgrqYM6vl3on9UtV3g==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-icons": "47.3.0",
-        "@ckeditor/ckeditor5-mention": "47.3.0",
-        "@ckeditor/ckeditor5-typing": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "ckeditor5": "47.3.0",
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-icons": "47.7.2",
+        "@ckeditor/ckeditor5-mention": "47.7.2",
+        "@ckeditor/ckeditor5-typing": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "ckeditor5": "47.7.2",
         "es-toolkit": "1.39.5",
         "fuzzysort": "3.1.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-engine": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-47.3.0.tgz",
-      "integrity": "sha512-op/9TsJgFtWctfUd/QY41HYyFZd5hfSK6hBTJh0Xpz2XAfvpWsVim27FyWX0yIhyMLmtwDETDq8iBaH5kEZ15g==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-47.7.2.tgz",
+      "integrity": "sha512-ePWi/6NwoKOHu37D8N/mYXYl88E9yfs/8Zrmd4haccIFB45hKx9KO75Onfa1OuWJI+ueVl641UvRMLTRatWgzg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-utils": "47.3.0",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-enter": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-47.3.0.tgz",
-      "integrity": "sha512-gBsT2ffLKUQclJpWkjn8mggtmoa3AfYH6vjsfMefN3yov1FoGY65kQDXl9KOfdG71E/tRtOZkMUPXqZUlYrBlA==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-47.7.2.tgz",
+      "integrity": "sha512-rfUa6ntaiOD2ZeDHNcK24fDiwmd84U0x7cWhF5GlOMdFNtQHMjQHXTD3k5yycVlDVx0ZM0cQPDNc0lvk+BnJJQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-engine": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0"
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-engine": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-essentials": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-47.3.0.tgz",
-      "integrity": "sha512-tLqgNXfdZJiBR56CHBNkrHWd7WCSPTIRxfqB9xoDvFD3AQngv1J3tIj3ye0WtTr8V23CCcXzz3v3NFZwtuDPBw==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-47.7.2.tgz",
+      "integrity": "sha512-IBCumHHh6p+wo8hEyADmJ4yH/QeaMsksJcq2hBYuWdsErPR4IvcgbnD3nELCQfaKy4MkcI5qUnLnnFx840d87Q==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "47.3.0",
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-enter": "47.3.0",
-        "@ckeditor/ckeditor5-select-all": "47.3.0",
-        "@ckeditor/ckeditor5-typing": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-undo": "47.3.0",
-        "ckeditor5": "47.3.0"
+        "@ckeditor/ckeditor5-clipboard": "47.7.2",
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-enter": "47.7.2",
+        "@ckeditor/ckeditor5-select-all": "47.7.2",
+        "@ckeditor/ckeditor5-typing": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-undo": "47.7.2",
+        "ckeditor5": "47.7.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-find-and-replace": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-47.3.0.tgz",
-      "integrity": "sha512-jSbc4ss36ynQvyNYKNR4UXceoS8r2JE9fjedHZbMPpFRPlypCC2oc21WhWa/Fo+PcfAIV7q2izNDclcFtEFB/A==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-47.7.2.tgz",
+      "integrity": "sha512-uhyRbv4gyjwes1bvQlR8RUeiWthlAULnOH7QNiUhuBLPLJlZmmn78TamRkeAU895ef0De3z0C4kWnM10fpCLTg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-icons": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "ckeditor5": "47.3.0",
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-icons": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "ckeditor5": "47.7.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-font": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-47.3.0.tgz",
-      "integrity": "sha512-J1QhW0Z6LfU0Mc3cITw21vPTIv1sGtlyO7JSFU9rQUkF1p2PCMQ/SvEja3bdz8LipidoDUh+QCeT2z9TSt1VDA==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-47.7.2.tgz",
+      "integrity": "sha512-oXQ5L67Mqy9z6Pkw5SRDJ3XsdROyBA0NHx35fOun0F+rYaBLOYNrge1dQwddRmCKdt3Zk+w8y7vSAKH+LcKepg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-engine": "47.3.0",
-        "@ckeditor/ckeditor5-icons": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "ckeditor5": "47.3.0"
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-engine": "47.7.2",
+        "@ckeditor/ckeditor5-icons": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "ckeditor5": "47.7.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-fullscreen": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-fullscreen/-/ckeditor5-fullscreen-47.3.0.tgz",
-      "integrity": "sha512-lSge/Lw30GYkztAWifZYOpc5Q9tjuT73gq0Hcs1tDpiIIt63CM7AfIS/sjiTUus0ZSG8fjLdd3ivSf4TiE/kOg==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-fullscreen/-/ckeditor5-fullscreen-47.7.2.tgz",
+      "integrity": "sha512-TibEj1hRD+M8M/RIWAvElki/QqOvrenEx0aZQAKa6mOmnWpf8icVeNuZXEQxuRkATQ6BPiXqE+AW9yBk9rISww==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-editor-classic": "47.3.0",
-        "@ckeditor/ckeditor5-editor-decoupled": "47.3.0",
-        "@ckeditor/ckeditor5-icons": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "ckeditor5": "47.3.0"
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-editor-classic": "47.7.2",
+        "@ckeditor/ckeditor5-editor-decoupled": "47.7.2",
+        "@ckeditor/ckeditor5-icons": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "ckeditor5": "47.7.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-heading": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-47.3.0.tgz",
-      "integrity": "sha512-sCBpuGTY+RGnE45r1cgFfe29cW6hmVQo+4HGppyErj7Sac5f1PCG84/DSTP1n+6LPiA51Yh2Z/VtQdYKMRNnmQ==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-47.7.2.tgz",
+      "integrity": "sha512-r+MQoqUYNvOtPj1HPrb9ctyvl8LruBsMo6fgXAwDhFBhhVXCRKvH7C4zKnmJ6jJ+J2XA4NbEg+oT1UeFGxGAWQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-engine": "47.3.0",
-        "@ckeditor/ckeditor5-icons": "47.3.0",
-        "@ckeditor/ckeditor5-paragraph": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "ckeditor5": "47.3.0"
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-engine": "47.7.2",
+        "@ckeditor/ckeditor5-icons": "47.7.2",
+        "@ckeditor/ckeditor5-paragraph": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "ckeditor5": "47.7.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-highlight": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-47.3.0.tgz",
-      "integrity": "sha512-wlT7R+7LVp0LmCyKIRN+U6+3FJqw6NpmfHhidSZnTRd9qzGnZ2EMxdEIkfOyCZd2CYH/gxtf/QFGik+DTjV/ow==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-47.7.2.tgz",
+      "integrity": "sha512-i+G6nNzgQSWjTy3bh4khfShHqpVNeVLoWXhHe+QTJ2rN6dAj646X4NhA3vauXNm+ZISrM1LiqJIpdG6wtyEewg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-icons": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "ckeditor5": "47.3.0"
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-engine": "47.7.2",
+        "@ckeditor/ckeditor5-icons": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "ckeditor5": "47.7.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-horizontal-line": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-47.3.0.tgz",
-      "integrity": "sha512-F0QlRncwX/wvUN/LtZjpdsld9qT3jDxrniv4a/nz4LIotTVAsw2tMy9y8Sw2TNjIrOY5cCytxG91kzc+WNwUlA==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-47.7.2.tgz",
+      "integrity": "sha512-y5xTsbNoe57Clz4O889XBmCsnud7QsnRTVRb7VoLqbwv88syGcQukf8nP2cRgfXVKBM9qlMFGqTqx1clOkz4gQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-icons": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "@ckeditor/ckeditor5-widget": "47.3.0",
-        "ckeditor5": "47.3.0"
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-icons": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "@ckeditor/ckeditor5-widget": "47.7.2",
+        "ckeditor5": "47.7.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-html-embed": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-47.3.0.tgz",
-      "integrity": "sha512-B8xgh/4fUoccNhTKajBFlWWgz03G0QS41iXGtEoDY74Z1Ewx8zKccw4kPcyowIsrM7iq8w8tmo7uHJQaB5rhlA==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-47.7.2.tgz",
+      "integrity": "sha512-f7TuksEc7QqCSTqZ8IW8zlh8yBA4VaDon1MJGFx7we1wQb6wFjyNSM9oUKp6LC/Rpo3F0crop9fNo/9/L2jl1g==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-icons": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "@ckeditor/ckeditor5-widget": "47.3.0",
-        "ckeditor5": "47.3.0"
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-icons": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "@ckeditor/ckeditor5-widget": "47.7.2",
+        "ckeditor5": "47.7.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-html-support": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-47.3.0.tgz",
-      "integrity": "sha512-sdqB2NPlCy4UC6Wgi1RzW/kzeWd9zIgf8s/bx4KzGbWekAvfnJWUVAYkkziM+7N6NhXTKDx8Wu2Zh/66pIo1XA==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-47.7.2.tgz",
+      "integrity": "sha512-Drq1C9/hDtynIrEU7HNn4LzOBawaONjVsvqFyPQYwlcpNzyh9xt81SGJWQNtu0bT0LKTGCMNFhPTPq9zo9SrTQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-engine": "47.3.0",
-        "@ckeditor/ckeditor5-enter": "47.3.0",
-        "@ckeditor/ckeditor5-heading": "47.3.0",
-        "@ckeditor/ckeditor5-image": "47.3.0",
-        "@ckeditor/ckeditor5-list": "47.3.0",
-        "@ckeditor/ckeditor5-remove-format": "47.3.0",
-        "@ckeditor/ckeditor5-table": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "@ckeditor/ckeditor5-widget": "47.3.0",
-        "ckeditor5": "47.3.0",
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-engine": "47.7.2",
+        "@ckeditor/ckeditor5-enter": "47.7.2",
+        "@ckeditor/ckeditor5-heading": "47.7.2",
+        "@ckeditor/ckeditor5-image": "47.7.2",
+        "@ckeditor/ckeditor5-list": "47.7.2",
+        "@ckeditor/ckeditor5-remove-format": "47.7.2",
+        "@ckeditor/ckeditor5-table": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "@ckeditor/ckeditor5-widget": "47.7.2",
+        "ckeditor5": "47.7.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-icons": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-icons/-/ckeditor5-icons-47.3.0.tgz",
-      "integrity": "sha512-erpbkXiPtA3Bu8a8ZLQjPYpX4W0WoT3OFZElHZgXOmVl8xQAefp2q+lFYKgzsqB757/zZO7i/B6U9czNv6lPmw==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-icons/-/ckeditor5-icons-47.7.2.tgz",
+      "integrity": "sha512-zFp5mjwREI/rjoiEzf+wmLl0ORKVOm3XOKRoA6ffV6NTGh7naWX8E9ULplHElFAZ/v49/Xu+HcPy/Nt7KbZg2w==",
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/@ckeditor/ckeditor5-image": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-47.3.0.tgz",
-      "integrity": "sha512-KnsQUv1itQdKJIAlj3GSTETuaiyFq7ggMsK7UVJFTk0yCiIi+oSEkrIn5r+p1e98QYEYjArS2SwOIxDsxDM2sQ==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-47.7.2.tgz",
+      "integrity": "sha512-PO8hepn/l504qoLTZ75TL272t9vZtfqiggiOP5//vIUJXIHG6+TDNSH71FdhMKcJxTsTPdvxQDUAhHBOeP+TCw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "47.3.0",
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-engine": "47.3.0",
-        "@ckeditor/ckeditor5-icons": "47.3.0",
-        "@ckeditor/ckeditor5-typing": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-undo": "47.3.0",
-        "@ckeditor/ckeditor5-upload": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "@ckeditor/ckeditor5-widget": "47.3.0",
-        "ckeditor5": "47.3.0",
+        "@ckeditor/ckeditor5-clipboard": "47.7.2",
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-engine": "47.7.2",
+        "@ckeditor/ckeditor5-icons": "47.7.2",
+        "@ckeditor/ckeditor5-typing": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-undo": "47.7.2",
+        "@ckeditor/ckeditor5-upload": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "@ckeditor/ckeditor5-widget": "47.7.2",
+        "ckeditor5": "47.7.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-indent": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-47.3.0.tgz",
-      "integrity": "sha512-kIpuMrTrtf7YhOBYre2Ny7NnL/x6sqMzdaxy4LN+4Sa9+Cw+KR2QJij2d0VkwDzV+z2B8GZ1mNZvCzpEwWDUUA==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-47.7.2.tgz",
+      "integrity": "sha512-Bop58P7Y/bJ/RCb1x/mN/nuCULyX++VCRFRx8Ob/UdqV9dHKSJIxFN0kVmeUu0wyq/2boJdoJqD49BOy68j/Uw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-engine": "47.3.0",
-        "@ckeditor/ckeditor5-heading": "47.3.0",
-        "@ckeditor/ckeditor5-icons": "47.3.0",
-        "@ckeditor/ckeditor5-list": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "ckeditor5": "47.3.0"
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-engine": "47.7.2",
+        "@ckeditor/ckeditor5-heading": "47.7.2",
+        "@ckeditor/ckeditor5-icons": "47.7.2",
+        "@ckeditor/ckeditor5-list": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "ckeditor5": "47.7.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-integrations-common": {
@@ -518,65 +521,67 @@
       }
     },
     "node_modules/@ckeditor/ckeditor5-language": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-47.3.0.tgz",
-      "integrity": "sha512-sPAgbKYT3NpofS2FWphkgiPzD2YqbTpxpLyzHymDJo7s2LQWj5FUGacZiiddGPOdzicSasZ6qHvcHIMHCmLBpg==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-47.7.2.tgz",
+      "integrity": "sha512-rrb8V4Jc0B2k+tJIdgWuKOBrHwfmP1+3RqdHQT0FhJt7qeUnaLrT5zyCa8lnZmexReaNlxlW1PJwN3d/qvyNrw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "ckeditor5": "47.3.0"
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-engine": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "ckeditor5": "47.7.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-link": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-47.3.0.tgz",
-      "integrity": "sha512-YbxZQHi36EF/O7deiDlrM8Xnw/J18x4dQgxaiHKTSHu7/4sZuVfJFAzF6afdt1uQ+8yeX3+q60jkJr2mm1zOEw==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-47.7.2.tgz",
+      "integrity": "sha512-UpmqPjYVxXc83kDP8b2nBmmZkOV8pkyrmOtesCBu3SbQS0rZTV5+WqhpgdW3/KmsFwNbK9W3ErEee4DLI9RT8A==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "47.3.0",
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-engine": "47.3.0",
-        "@ckeditor/ckeditor5-icons": "47.3.0",
-        "@ckeditor/ckeditor5-image": "47.3.0",
-        "@ckeditor/ckeditor5-typing": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "@ckeditor/ckeditor5-widget": "47.3.0",
-        "ckeditor5": "47.3.0",
+        "@ckeditor/ckeditor5-clipboard": "47.7.2",
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-engine": "47.7.2",
+        "@ckeditor/ckeditor5-icons": "47.7.2",
+        "@ckeditor/ckeditor5-image": "47.7.2",
+        "@ckeditor/ckeditor5-typing": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "@ckeditor/ckeditor5-widget": "47.7.2",
+        "ckeditor5": "47.7.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-list": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-47.3.0.tgz",
-      "integrity": "sha512-iOJ4prpoqf1UamKztQ0If/k638+NGSPsFaGGjOqhGPcIJxTtscs4c34uNUH6yCXDNF1ZaET2FxFckAQvrb0DFQ==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-47.7.2.tgz",
+      "integrity": "sha512-AqF4omEDl75dsUww624B/2fAzvko1D7xHDsXtbkaV8qG1S38l53TS7bzNzXvYctioj1NXa/twu8KnCNt0gmiGg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "47.3.0",
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-engine": "47.3.0",
-        "@ckeditor/ckeditor5-enter": "47.3.0",
-        "@ckeditor/ckeditor5-font": "47.3.0",
-        "@ckeditor/ckeditor5-icons": "47.3.0",
-        "@ckeditor/ckeditor5-typing": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "ckeditor5": "47.3.0"
+        "@ckeditor/ckeditor5-clipboard": "47.7.2",
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-engine": "47.7.2",
+        "@ckeditor/ckeditor5-enter": "47.7.2",
+        "@ckeditor/ckeditor5-font": "47.7.2",
+        "@ckeditor/ckeditor5-icons": "47.7.2",
+        "@ckeditor/ckeditor5-typing": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "ckeditor5": "47.7.2",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-markdown-gfm": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-47.3.0.tgz",
-      "integrity": "sha512-PyRXnwnUmwW7pxe8DaV1sle/g45fp/e+1vzXgFIvLYWJO5i2Sych1yDbAU1RGbJr5R05eFS7Fov3bowzRE2ICA==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-47.7.2.tgz",
+      "integrity": "sha512-u8BHbcC9D9fsAy7AidxswB7jld9dwguaUhsGI6FmFl25Skze+wG3XZ19f0jbWS2GdlXGA8OpU0LYUh7mhwGeog==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "47.3.0",
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-engine": "47.3.0",
+        "@ckeditor/ckeditor5-clipboard": "47.7.2",
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-engine": "47.7.2",
         "@types/hast": "3.0.4",
-        "ckeditor5": "47.3.0",
+        "ckeditor5": "47.7.2",
         "hast-util-from-dom": "5.0.1",
         "hast-util-to-html": "9.0.5",
         "hast-util-to-mdast": "10.1.2",
@@ -594,87 +599,87 @@
       }
     },
     "node_modules/@ckeditor/ckeditor5-media-embed": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-47.3.0.tgz",
-      "integrity": "sha512-c0wP3VZp6409VMMRYL4z2ZiqCsP2p4RyHcfH8TZSy3g25pZnUbYpdMepHCxT0U5wLVdqhGMn7cW+k5Fq6Mp/hA==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-47.7.2.tgz",
+      "integrity": "sha512-qksYj+fvnnTGqKVDahIaYO3oZBhpxQ/rx5qgmx3LIFDDxHJlY6dRjqIciJ2xtSCSKos8w5zjsyVHMhSp8LCg+A==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "47.3.0",
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-engine": "47.3.0",
-        "@ckeditor/ckeditor5-icons": "47.3.0",
-        "@ckeditor/ckeditor5-typing": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-undo": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "@ckeditor/ckeditor5-widget": "47.3.0",
-        "ckeditor5": "47.3.0"
+        "@ckeditor/ckeditor5-clipboard": "47.7.2",
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-engine": "47.7.2",
+        "@ckeditor/ckeditor5-icons": "47.7.2",
+        "@ckeditor/ckeditor5-typing": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-undo": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "@ckeditor/ckeditor5-widget": "47.7.2",
+        "ckeditor5": "47.7.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-mention": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-47.3.0.tgz",
-      "integrity": "sha512-yIRbRSd0b66kUlur80kiskVMyymHvtg96endZ8FuGDjKgdLApFnkonNmpCNLAxGuwJDMfDyvyEikZy1i0bgWlg==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-47.7.2.tgz",
+      "integrity": "sha512-CdoBqc6jgU8ttOIA/0gq1x1bHOMbPIWeBjWeBesk6kD+izTc//RCDtxfacgbOL0V3lGdWUQytHLoW6Yof1PiZg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-typing": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "ckeditor5": "47.3.0",
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-typing": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "ckeditor5": "47.7.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-minimap": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-47.3.0.tgz",
-      "integrity": "sha512-8JrmRwEMdIVoSp5Xms8sWHxlXcBPwhf7HjY35ptbS2sMQQ4RC9o5tbyLe8V2kGt8Qgmvx3F2H2VT9VFpQCUmFg==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-47.7.2.tgz",
+      "integrity": "sha512-onkQQ1x1GabwC/vyVQBD3smJXM+qUQ7y3xzuad9BfHqa9TxPSRhKVh8BJAG1D/+GKLGN+6vl4qiCkOXjhSoI+g==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-engine": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "ckeditor5": "47.3.0"
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-engine": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "ckeditor5": "47.7.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-page-break": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-47.3.0.tgz",
-      "integrity": "sha512-ZvLfObeXnhYKs8+kcVBbjpAWQnGelVopnEIC0Ljds2cxyeUJ25pnLAZGKMcEOFvdm8Hh1OKnlfPWj3VRZMkrVw==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-47.7.2.tgz",
+      "integrity": "sha512-xiS7kuMQDq5wHSTXK7cJKGnnKVXjYf8PPG//PbQlXdBr2A4qaNOBb1LmIeQOZNPTrGwT0pg34rVpDoC4YbY5rA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-icons": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "@ckeditor/ckeditor5-widget": "47.3.0",
-        "ckeditor5": "47.3.0"
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-icons": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "@ckeditor/ckeditor5-widget": "47.7.2",
+        "ckeditor5": "47.7.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-paragraph": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-47.3.0.tgz",
-      "integrity": "sha512-CCnCd57ySxYrb6XCocAzj49PH6jOc+YbsgVVQ4+4sMyOQR/d5VdgJAkQKO7m288nwvE+Ai9gMAl5rqiph+PcMg==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-47.7.2.tgz",
+      "integrity": "sha512-063dVxZnLn0qduNx/+qfia7ygN9rjIXsc19uYEAlLe6fwYJJjDeqvcJ9YyAKi8kbkAraLMlmZPN40YwCq1Z6Nw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-engine": "47.3.0",
-        "@ckeditor/ckeditor5-icons": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0"
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-engine": "47.7.2",
+        "@ckeditor/ckeditor5-icons": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-paste-from-office": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-47.3.0.tgz",
-      "integrity": "sha512-8M7pKMAI0cwviVx/QWYQRDfy9GLUUBVKrqBFuOu/lcxfsncL7BUJYVVvaOC+iN0I9Mi513XHz78FLi4PbRoC0A==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-47.7.2.tgz",
+      "integrity": "sha512-f7E9uDX9T4Ug8/rSYB9yU7CVERZmkzJG9P6PI8Rmp4qyT3AUmmlKvR21IIMXiul7RN9XJin+AaGgwPjPV5xj4g==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "47.3.0",
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-engine": "47.3.0",
-        "ckeditor5": "47.3.0"
+        "@ckeditor/ckeditor5-clipboard": "47.7.2",
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-engine": "47.7.2",
+        "ckeditor5": "47.7.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-react": {
@@ -691,152 +696,152 @@
       }
     },
     "node_modules/@ckeditor/ckeditor5-remove-format": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-47.3.0.tgz",
-      "integrity": "sha512-tGBSxVKu2fUO7oH2U4QyAb6+/47YFkEVwRPGvpwg4QUQn670qAJJenJBWqXEYFHK6V5mLDfD5xmKdTk79OXgTw==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-47.7.2.tgz",
+      "integrity": "sha512-uK4UtjqvPohQfLSDQDZQz117dgU490BLlxRg9OT21xJNFRbi4tEo8yt/Bd7KFZ+f6fx6D4ahEY6y/9+Njwav0w==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-icons": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "ckeditor5": "47.3.0"
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-icons": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "ckeditor5": "47.7.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-restricted-editing": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-47.3.0.tgz",
-      "integrity": "sha512-DoJFgX7RXapubLnulcW6aFuTQD25jSPWMJA25EXHTHMq9ZQP69ey2kJgp2iioas0zpsKhnVzioUyIiGe28ufng==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-47.7.2.tgz",
+      "integrity": "sha512-wnkCjDQbqt0CiceTaU1hTyKjIc/926MXAhowQwSXAUbkj34ME3fXCQqtoaCFPw+23PNPQ+D3iTnJVivNZbJS3A==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-engine": "47.3.0",
-        "@ckeditor/ckeditor5-icons": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "ckeditor5": "47.3.0"
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-engine": "47.7.2",
+        "@ckeditor/ckeditor5-icons": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "ckeditor5": "47.7.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-select-all": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-47.3.0.tgz",
-      "integrity": "sha512-pMWVdKDlLowiwnVGycJd0mW2jQ3HdlzzstfIhawhU2jspSY4Byk8XiPZ9Dyq6aAwEtdJOShLLau1dcVnB2OltA==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-47.7.2.tgz",
+      "integrity": "sha512-1MhEjBR42apV0sljaKKcwS5QNzTfGmiK8/YDXALkP2bHJMrSNQFwzZOxA6ZyS9I4f3m8UFUgoYy7mz/ewTxvEA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-engine": "47.3.0",
-        "@ckeditor/ckeditor5-icons": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0"
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-engine": "47.7.2",
+        "@ckeditor/ckeditor5-icons": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-show-blocks": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-47.3.0.tgz",
-      "integrity": "sha512-vgmH/FqCHproRvVqXYLQrDeDgc5D+2iEK/MB7sRH75w+ZjP495XUYRtoZWud59yQ8P3kCgywycR74iyenxntlw==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-47.7.2.tgz",
+      "integrity": "sha512-EXhh0zUxA1cus4xuRhnCR/gUTmZxgLggYEng5Iijg2ptZOv5Zjq/d3VHWgVTFh/u9ayMAOt4pUDHdDQXf0Hdvg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-icons": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "ckeditor5": "47.3.0"
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-icons": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "ckeditor5": "47.7.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-source-editing": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-47.3.0.tgz",
-      "integrity": "sha512-a2hFkyUzDJBpPh5jF3+LUO356PeQ84/Amqp9Y8oqzk6nKXlfr5IdPU1kQTkwDxee7F85EUNd2/wRZm4tLKL02A==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-47.7.2.tgz",
+      "integrity": "sha512-mZaZMaDKQh7sP52o3e3Q9O+eLU0bnr4jSZZTl0FnZ9JLjZ+tGmeEVdaBPnuFUviriIiBqfb6rrdrq8l4m93yeg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-icons": "47.3.0",
-        "@ckeditor/ckeditor5-theme-lark": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "ckeditor5": "47.3.0"
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-icons": "47.7.2",
+        "@ckeditor/ckeditor5-theme-lark": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "ckeditor5": "47.7.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-special-characters": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-47.3.0.tgz",
-      "integrity": "sha512-kh9gONY8HqP1hQ5AImLzYyiecyVRHmyGE9xc1koyOV5HvZ3X+ogTWuAFqG5e3zjLaVCeKQKXkbuBS6/+Gi2NxQ==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-47.7.2.tgz",
+      "integrity": "sha512-Ia9sU1DH9Xsqb+KXXidSB9uTISYanBZyUoN5scVUGHzeZFaAv3WFniyZTtrj6bAjEdIgkwpJ0zMqYRj1H+l0tQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-icons": "47.3.0",
-        "@ckeditor/ckeditor5-typing": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "ckeditor5": "47.3.0"
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-icons": "47.7.2",
+        "@ckeditor/ckeditor5-typing": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "ckeditor5": "47.7.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-style": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-47.3.0.tgz",
-      "integrity": "sha512-EsQ3ZZccrsniKadcfjBI7HJgsNbZAl6NomQBKauvTQzmOoL90Ouffp6yIQTIQkIgm/xzIh2zVhGTcw84VoioJw==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-47.7.2.tgz",
+      "integrity": "sha512-hzecrmmndIQNh1cSIFJDqjiomdoU2T+wgVd1hQbJZGfU+YbrXcQd+Im/AUUhdjgmzUCXNtyPQxJBZmFKe/YJDg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-html-support": "47.3.0",
-        "@ckeditor/ckeditor5-list": "47.3.0",
-        "@ckeditor/ckeditor5-table": "47.3.0",
-        "@ckeditor/ckeditor5-typing": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "ckeditor5": "47.3.0",
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-html-support": "47.7.2",
+        "@ckeditor/ckeditor5-list": "47.7.2",
+        "@ckeditor/ckeditor5-table": "47.7.2",
+        "@ckeditor/ckeditor5-typing": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "ckeditor5": "47.7.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-table": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-47.3.0.tgz",
-      "integrity": "sha512-YVupV2lEvE8tJi2tSnrthT1GCdzA0+zv4x0AQR5fBKfu82fux7vxKb222UnHkHhazrR3dGY5MSBRjIaDerY3TA==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-47.7.2.tgz",
+      "integrity": "sha512-h59RtJM6xqmMu6oN0J5IJvD6gISmdMOS2vI2V551hLVlxJzi9CMomHIVX+D/xaWhQzYDi5fA9edbVhwx1YpP6g==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "47.3.0",
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-engine": "47.3.0",
-        "@ckeditor/ckeditor5-icons": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "@ckeditor/ckeditor5-widget": "47.3.0",
-        "ckeditor5": "47.3.0",
+        "@ckeditor/ckeditor5-clipboard": "47.7.2",
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-engine": "47.7.2",
+        "@ckeditor/ckeditor5-icons": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "@ckeditor/ckeditor5-widget": "47.7.2",
+        "ckeditor5": "47.7.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-theme-lark": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-47.3.0.tgz",
-      "integrity": "sha512-ovaRKQAVTqlmYlpo3y9q1iu+5SKmmdjBTFDRGRgZ9nXNuD2vmikJA4pG5A4aNKLl/d3/LIkPfbn2g2w9VIlb7Q==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-47.7.2.tgz",
+      "integrity": "sha512-XGOHT9nY0XTdjLmuq+Sdu2ayQ8OkjC2W6A65ykjkPOVJROKmNolwt9ApXLuCAkTIPYBMZvxuaqcMOWW6P5pOyw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-ui": "47.3.0"
+        "@ckeditor/ckeditor5-ui": "47.7.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-typing": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-47.3.0.tgz",
-      "integrity": "sha512-hxwdd4hcCXLMFehS9/DLlcl+Bx+TlF+gG8f1DqNmpmqRbbVtfMFfMlHuqKC7+0c3TLJz7f0F5ih681s2H4t9RA==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-47.7.2.tgz",
+      "integrity": "sha512-YvI56n1HpX2fUJ74BTWxV41SetZs1VTuYHyAzHRerxJ+VWJPmxuSiyu2l9CyshFj9ePn8MMuyjYzS45dviuZgw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-engine": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-engine": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-ui": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-47.3.0.tgz",
-      "integrity": "sha512-dDHvfIxNfo3z00KwDO6nHCx9ZC2vVEQ+lMmpjbMD8P3FzGRPRd7NqzRbPoieDKlgAiG6Sa2CLThqA+71C+RMfw==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-47.7.2.tgz",
+      "integrity": "sha512-0D3khcUUCbPE2sH4quivlCpZr83A7FZWKP7Y5uG+Hr1olO+3ULNeRDc//qjlWlyffFR6SAvuQ32JuIW74hG0mw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-editor-multi-root": "47.3.0",
-        "@ckeditor/ckeditor5-engine": "47.3.0",
-        "@ckeditor/ckeditor5-icons": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-editor-multi-root": "47.7.2",
+        "@ckeditor/ckeditor5-engine": "47.7.2",
+        "@ckeditor/ckeditor5-icons": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
         "@types/color-convert": "2.0.4",
         "color-convert": "3.1.0",
         "color-parse": "2.0.2",
@@ -866,77 +871,77 @@
       }
     },
     "node_modules/@ckeditor/ckeditor5-undo": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-47.3.0.tgz",
-      "integrity": "sha512-vO0WCOQBC1Cj7hCxh3+VhQNrANiBjj+8561XkLGhDpQt/lpzuEqXn11Rx4BXjSzpuDZvNnMNO9duzXfEfVjAzw==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-47.7.2.tgz",
+      "integrity": "sha512-FYwe9bOz0Y5nk6f/zAE0VcbMcHu9rk8Ymd5PpnBs6qWtpdW70K48qVD34HyzXSQ1Zo/qLk4/ZcXzKs+ZtJ/csA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-engine": "47.3.0",
-        "@ckeditor/ckeditor5-icons": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0"
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-engine": "47.7.2",
+        "@ckeditor/ckeditor5-icons": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-upload": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-47.3.0.tgz",
-      "integrity": "sha512-j4GngBlxg/tjztS/B67RD/OUrTYQhrwDYSpAjXV6shabwEbtEadsKLYgpXPR12ENB30mmrYKIRC/pgT5/wXc6Q==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-47.7.2.tgz",
+      "integrity": "sha512-iFy/i++U2k86G6Rn8KCkns+TW8Iqzo/gCjDt+/681NGGmq2Js+4c2Vvdo3mItWWiAvstvh39CSNiEyeebqOT6A==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0"
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-utils": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-47.3.0.tgz",
-      "integrity": "sha512-RF5iAkI7NpVYZW1Fo+BhIQmPNLqA6iRVNoqo43P7vE8QfvG0fYB1Ff3jsEeM4UVV/G6pABBhE+9UMpwJcBuxWw==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-47.7.2.tgz",
+      "integrity": "sha512-FLu29d9nkN+T7EH81NHEBPxmCWLiG8FRDR71I6BZbRPCPcwLBau1Rct8qHhQT6sKwxHnEDB9nc5Ix7PLi8lAXQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-ui": "47.3.0",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-watchdog": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-47.3.0.tgz",
-      "integrity": "sha512-gurXEgfiIvnmmd7u68PdffdAaYFuNuAE8fJoWeJFMzrrFGuG7TvGmulXG/Wom2D4D+eW7wQE93Sisx9wIfAcPQ==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-47.7.2.tgz",
+      "integrity": "sha512-x3HYJFjxDGC9AjGac+V9L94MqyVxkMDLIHuZVeXoPHju/nQ202rjFR1C1k6k8TBiHY9hIYy0tjiNL4Aj7cTC0Q==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-editor-multi-root": "47.3.0",
-        "@ckeditor/ckeditor5-engine": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-editor-multi-root": "47.7.2",
+        "@ckeditor/ckeditor5-engine": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-widget": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-47.3.0.tgz",
-      "integrity": "sha512-8IagE3JdKLM04KB3XR2SCDJTIlmtGOhkfWZBn9kwy7g8SIjI2bJARA/0wgXMGlzUV2AMbbxb0HdkMEK6Xxg/nQ==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-47.7.2.tgz",
+      "integrity": "sha512-CQwaDO/whv5Wed4otnUiwHlShq0N6SYr0KByDSiuYcxkxahgTXVgWKbT+1JDgEkOzz9Lzyj2ZZeWfL4RuCjhmg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-engine": "47.3.0",
-        "@ckeditor/ckeditor5-enter": "47.3.0",
-        "@ckeditor/ckeditor5-icons": "47.3.0",
-        "@ckeditor/ckeditor5-typing": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-engine": "47.7.2",
+        "@ckeditor/ckeditor5-enter": "47.7.2",
+        "@ckeditor/ckeditor5-icons": "47.7.2",
+        "@ckeditor/ckeditor5-typing": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-word-count": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-47.3.0.tgz",
-      "integrity": "sha512-VluTjPWaJnYS6uoJfi8XJZIBPzfrARH4RBEHOBto4SM1jNdSV0gltz6jfNSteGXm4Bl+VdBgltzRAXqsugi2Vg==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-47.7.2.tgz",
+      "integrity": "sha512-60SJ4eHPupVj9TzTDhDC/25iahHJ2DuTuDKrEO47z9jsby5Elnf8z47airfglfC8puB8dku+SUPrMeNPTRbXUA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "ckeditor5": "47.3.0",
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "ckeditor5": "47.7.2",
         "es-toolkit": "1.39.5"
       }
     },
@@ -1356,20 +1361,22 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -1385,6 +1392,47 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@fast-csv/format": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@fast-csv/format/-/format-4.3.5.tgz",
+      "integrity": "sha512-8iRn6QF3I8Ak78lNAa+Gdl5MJJBM5vRHivFtMRUWINdevNo00K7OXxS2PshawLKTejVwieIlPmK5YlLu6w4u8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^14.0.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isequal": "^4.5.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0"
+      }
+    },
+    "node_modules/@fast-csv/format/node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "license": "MIT"
+    },
+    "node_modules/@fast-csv/parse": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@fast-csv/parse/-/parse-4.3.6.tgz",
+      "integrity": "sha512-uRsLYksqpbDmWaSmzvJcuApSEe38+6NQZBUsuAyMZKqHxH0g1wcJgsKUvN3WC8tewaqFjBMMGrkHmC+T7k8LvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^14.0.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.groupby": "^4.6.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0",
+        "lodash.isundefined": "^3.0.1",
+        "lodash.uniq": "^4.5.0"
+      }
+    },
+    "node_modules/@fast-csv/parse/node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "license": "MIT"
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
@@ -1402,20 +1450,22 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -1479,208 +1529,389 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.18.0.tgz",
-      "integrity": "sha512-Tya6xypR10giZV1XzxmH5wr25VcZSncG0pZIjfePT0OVBvqNEurzValetGNarVrGiq66EBVAFn15iYX4w6FKgQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.18.0.tgz",
-      "integrity": "sha512-avCea0RAP03lTsDhEyfy+hpfr85KfyTctMADqHVhLAF3MlIkq83CP8UfAHUssgXTYd+6er6PaAhx/QGv4L1EiA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.18.0.tgz",
-      "integrity": "sha512-IWfdwU7KDSm07Ty0PuA/W2JYoZ4iTj3TUQjkVsO/6U+4I1jN5lcR71ZEvRh52sDOERdnNhhHU57UITXz5jC1/w==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.18.0.tgz",
-      "integrity": "sha512-n2LMsUz7Ynu7DoQrSQkBf8iNrjOGyPLrdSg802vk6XT3FtsgX6JbE8IHRvposskFm9SNxzkLYGSq9QdpLYpRNA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.18.0.tgz",
-      "integrity": "sha512-C/zbRYRXFjWvz9Z4haRxcTdnkPt1BtCkz+7RtBSuNmKzMzp3ZxdM28Mpccn6pt28/UWUCTXa+b0Mx1k3g6NOMA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.18.0.tgz",
-      "integrity": "sha512-l3m9ewPgjQSXrUMHg93vt0hYCGnrMOcUpTz6FLtbwljo2HluS4zTXFy2571YQbisTnfTKPZ01u/ukJdQTLGh9A==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.18.0.tgz",
-      "integrity": "sha512-rJ5D47d8WD7J+7STKdCUAgmQk49xuFrRi9pZkWoRD1UeSMakbcepWXPF8ycChBoAqs1pb2wzvbY6Q33WmN2ftw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.18.0.tgz",
-      "integrity": "sha512-be6Yx37b24ZwxQ+wOQXXLZqpq4jTckJhtGlWGZs68TgdKXJgw54lUUoFYrg6Zs/kjzAQwEwYbp8JxZVzZLRepQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.18.0.tgz",
-      "integrity": "sha512-hNVMQK+qrA9Todu9+wqrXOHxFiD5YmdEi3paj6vP02Kx1hjd2LLYR2eaN7DsEshg09+9uzWi2W18MJDlG0cxJA==",
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.18.0.tgz",
-      "integrity": "sha512-ROCM7i+m1NfdrsmvwSzoxp9HFtmKGHEqu5NNDiZWQtXLA8S5HBCkVvKAxJ8U+CVctHwV2Gb5VUaK7UAkzhDjlg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.18.0.tgz",
-      "integrity": "sha512-0UyyRHyDN42QL+NbqevXIIUnKA47A+45WyasO+y2bGJ1mhQrfrtXUpTxCOrfxCR4esV3/RLYyucGVPiUsO8xjg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.18.0.tgz",
-      "integrity": "sha512-xuglR2rBVHA5UsI8h8UbX4VJ470PtGCf5Vpswh7p2ukaqBGFTnsfzxUBetoWBWymHMxbIG0Cmx7Y9qDZzr648w==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.18.0.tgz",
-      "integrity": "sha512-LKaqQL9osY/ir2geuLVvRRs+utWUNilzdE90TpyoX0eNqPzWjRm14oMEE+YLve4k/NAqCdPkGYDaDF5Sw+xBfg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.18.0.tgz",
-      "integrity": "sha512-7J6TkZQFGo9qBKH0pk2cEVSRhJbL6MtfWxth7Y5YmZs57Pi+4x6c2dStAUvaQkHQLnEQv1jzBUW43GvZW8OFqA==",
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.18.0.tgz",
-      "integrity": "sha512-Txjh+IxBPbkUB9+SXZMpv+b/vnTEtFyfWZgJ6iyCmt2tdx0OF5WhFowLmnh8ENGNpfUlUZkdI//4IEmhwPieNg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.18.0.tgz",
-      "integrity": "sha512-UOo5FdvOL0+eIVTgS4tIdbW+TtnBLWg1YBCcU2KWM7nuNwRz9bksDX1bekJJCpu25N1DVWaCwnT39dVQxzqS8g==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1915,19 +2146,20 @@
       "license": "MIT"
     },
     "node_modules/@types/debug": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
-      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
       "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-      "dev": true
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/hast": {
       "version": "3.0.4",
@@ -2208,10 +2440,11 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2247,6 +2480,75 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/archiver": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.2.tgz",
+      "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^2.1.0",
+        "async": "^3.2.4",
+        "buffer-crc32": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^2.2.0",
+        "zip-stream": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+      "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/archiver-utils/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -2262,6 +2564,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
     "node_modules/bail": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
@@ -2275,8 +2583,66 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/big-integer": {
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "license": "MIT"
     },
     "node_modules/blurhash": {
       "version": "2.0.5",
@@ -2285,10 +2651,10 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -2303,6 +2669,56 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-indexof-polyfill": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
+      "engines": {
+        "node": ">=0.2.0"
       }
     },
     "node_modules/callsites": {
@@ -2322,6 +2738,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
+      "license": "MIT/X11",
+      "dependencies": {
+        "traverse": ">=0.3.0 <0.4"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/chalk": {
@@ -2371,72 +2799,72 @@
       }
     },
     "node_modules/ckeditor5": {
-      "version": "47.3.0",
-      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-47.3.0.tgz",
-      "integrity": "sha512-3UDvnAi8TB/5i9flEFfOLIQAIWUoIbucvvFCqKWJqpfZy3F3k34GLEgDV/3VM6O6QV+UNHbzYaSTAl4yKVvoXg==",
+      "version": "47.7.2",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-47.7.2.tgz",
+      "integrity": "sha512-aNNZ4JKJKLl1b2bUR84pRivOfGQGSmiXpk9DBPeEmoEf/3+ardjiLx63dIfkhOYjjX0xoDp5V6hH7QbH9aRxGQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-adapter-ckfinder": "47.3.0",
-        "@ckeditor/ckeditor5-alignment": "47.3.0",
-        "@ckeditor/ckeditor5-autoformat": "47.3.0",
-        "@ckeditor/ckeditor5-autosave": "47.3.0",
-        "@ckeditor/ckeditor5-basic-styles": "47.3.0",
-        "@ckeditor/ckeditor5-block-quote": "47.3.0",
-        "@ckeditor/ckeditor5-bookmark": "47.3.0",
-        "@ckeditor/ckeditor5-ckbox": "47.3.0",
-        "@ckeditor/ckeditor5-ckfinder": "47.3.0",
-        "@ckeditor/ckeditor5-clipboard": "47.3.0",
-        "@ckeditor/ckeditor5-cloud-services": "47.3.0",
-        "@ckeditor/ckeditor5-code-block": "47.3.0",
-        "@ckeditor/ckeditor5-core": "47.3.0",
-        "@ckeditor/ckeditor5-easy-image": "47.3.0",
-        "@ckeditor/ckeditor5-editor-balloon": "47.3.0",
-        "@ckeditor/ckeditor5-editor-classic": "47.3.0",
-        "@ckeditor/ckeditor5-editor-decoupled": "47.3.0",
-        "@ckeditor/ckeditor5-editor-inline": "47.3.0",
-        "@ckeditor/ckeditor5-editor-multi-root": "47.3.0",
-        "@ckeditor/ckeditor5-emoji": "47.3.0",
-        "@ckeditor/ckeditor5-engine": "47.3.0",
-        "@ckeditor/ckeditor5-enter": "47.3.0",
-        "@ckeditor/ckeditor5-essentials": "47.3.0",
-        "@ckeditor/ckeditor5-find-and-replace": "47.3.0",
-        "@ckeditor/ckeditor5-font": "47.3.0",
-        "@ckeditor/ckeditor5-fullscreen": "47.3.0",
-        "@ckeditor/ckeditor5-heading": "47.3.0",
-        "@ckeditor/ckeditor5-highlight": "47.3.0",
-        "@ckeditor/ckeditor5-horizontal-line": "47.3.0",
-        "@ckeditor/ckeditor5-html-embed": "47.3.0",
-        "@ckeditor/ckeditor5-html-support": "47.3.0",
-        "@ckeditor/ckeditor5-icons": "47.3.0",
-        "@ckeditor/ckeditor5-image": "47.3.0",
-        "@ckeditor/ckeditor5-indent": "47.3.0",
-        "@ckeditor/ckeditor5-language": "47.3.0",
-        "@ckeditor/ckeditor5-link": "47.3.0",
-        "@ckeditor/ckeditor5-list": "47.3.0",
-        "@ckeditor/ckeditor5-markdown-gfm": "47.3.0",
-        "@ckeditor/ckeditor5-media-embed": "47.3.0",
-        "@ckeditor/ckeditor5-mention": "47.3.0",
-        "@ckeditor/ckeditor5-minimap": "47.3.0",
-        "@ckeditor/ckeditor5-page-break": "47.3.0",
-        "@ckeditor/ckeditor5-paragraph": "47.3.0",
-        "@ckeditor/ckeditor5-paste-from-office": "47.3.0",
-        "@ckeditor/ckeditor5-remove-format": "47.3.0",
-        "@ckeditor/ckeditor5-restricted-editing": "47.3.0",
-        "@ckeditor/ckeditor5-select-all": "47.3.0",
-        "@ckeditor/ckeditor5-show-blocks": "47.3.0",
-        "@ckeditor/ckeditor5-source-editing": "47.3.0",
-        "@ckeditor/ckeditor5-special-characters": "47.3.0",
-        "@ckeditor/ckeditor5-style": "47.3.0",
-        "@ckeditor/ckeditor5-table": "47.3.0",
-        "@ckeditor/ckeditor5-theme-lark": "47.3.0",
-        "@ckeditor/ckeditor5-typing": "47.3.0",
-        "@ckeditor/ckeditor5-ui": "47.3.0",
-        "@ckeditor/ckeditor5-undo": "47.3.0",
-        "@ckeditor/ckeditor5-upload": "47.3.0",
-        "@ckeditor/ckeditor5-utils": "47.3.0",
-        "@ckeditor/ckeditor5-watchdog": "47.3.0",
-        "@ckeditor/ckeditor5-widget": "47.3.0",
-        "@ckeditor/ckeditor5-word-count": "47.3.0"
+        "@ckeditor/ckeditor5-adapter-ckfinder": "47.7.2",
+        "@ckeditor/ckeditor5-alignment": "47.7.2",
+        "@ckeditor/ckeditor5-autoformat": "47.7.2",
+        "@ckeditor/ckeditor5-autosave": "47.7.2",
+        "@ckeditor/ckeditor5-basic-styles": "47.7.2",
+        "@ckeditor/ckeditor5-block-quote": "47.7.2",
+        "@ckeditor/ckeditor5-bookmark": "47.7.2",
+        "@ckeditor/ckeditor5-ckbox": "47.7.2",
+        "@ckeditor/ckeditor5-ckfinder": "47.7.2",
+        "@ckeditor/ckeditor5-clipboard": "47.7.2",
+        "@ckeditor/ckeditor5-cloud-services": "47.7.2",
+        "@ckeditor/ckeditor5-code-block": "47.7.2",
+        "@ckeditor/ckeditor5-core": "47.7.2",
+        "@ckeditor/ckeditor5-easy-image": "47.7.2",
+        "@ckeditor/ckeditor5-editor-balloon": "47.7.2",
+        "@ckeditor/ckeditor5-editor-classic": "47.7.2",
+        "@ckeditor/ckeditor5-editor-decoupled": "47.7.2",
+        "@ckeditor/ckeditor5-editor-inline": "47.7.2",
+        "@ckeditor/ckeditor5-editor-multi-root": "47.7.2",
+        "@ckeditor/ckeditor5-emoji": "47.7.2",
+        "@ckeditor/ckeditor5-engine": "47.7.2",
+        "@ckeditor/ckeditor5-enter": "47.7.2",
+        "@ckeditor/ckeditor5-essentials": "47.7.2",
+        "@ckeditor/ckeditor5-find-and-replace": "47.7.2",
+        "@ckeditor/ckeditor5-font": "47.7.2",
+        "@ckeditor/ckeditor5-fullscreen": "47.7.2",
+        "@ckeditor/ckeditor5-heading": "47.7.2",
+        "@ckeditor/ckeditor5-highlight": "47.7.2",
+        "@ckeditor/ckeditor5-horizontal-line": "47.7.2",
+        "@ckeditor/ckeditor5-html-embed": "47.7.2",
+        "@ckeditor/ckeditor5-html-support": "47.7.2",
+        "@ckeditor/ckeditor5-icons": "47.7.2",
+        "@ckeditor/ckeditor5-image": "47.7.2",
+        "@ckeditor/ckeditor5-indent": "47.7.2",
+        "@ckeditor/ckeditor5-language": "47.7.2",
+        "@ckeditor/ckeditor5-link": "47.7.2",
+        "@ckeditor/ckeditor5-list": "47.7.2",
+        "@ckeditor/ckeditor5-markdown-gfm": "47.7.2",
+        "@ckeditor/ckeditor5-media-embed": "47.7.2",
+        "@ckeditor/ckeditor5-mention": "47.7.2",
+        "@ckeditor/ckeditor5-minimap": "47.7.2",
+        "@ckeditor/ckeditor5-page-break": "47.7.2",
+        "@ckeditor/ckeditor5-paragraph": "47.7.2",
+        "@ckeditor/ckeditor5-paste-from-office": "47.7.2",
+        "@ckeditor/ckeditor5-remove-format": "47.7.2",
+        "@ckeditor/ckeditor5-restricted-editing": "47.7.2",
+        "@ckeditor/ckeditor5-select-all": "47.7.2",
+        "@ckeditor/ckeditor5-show-blocks": "47.7.2",
+        "@ckeditor/ckeditor5-source-editing": "47.7.2",
+        "@ckeditor/ckeditor5-special-characters": "47.7.2",
+        "@ckeditor/ckeditor5-style": "47.7.2",
+        "@ckeditor/ckeditor5-table": "47.7.2",
+        "@ckeditor/ckeditor5-theme-lark": "47.7.2",
+        "@ckeditor/ckeditor5-typing": "47.7.2",
+        "@ckeditor/ckeditor5-ui": "47.7.2",
+        "@ckeditor/ckeditor5-undo": "47.7.2",
+        "@ckeditor/ckeditor5-upload": "47.7.2",
+        "@ckeditor/ckeditor5-utils": "47.7.2",
+        "@ckeditor/ckeditor5-watchdog": "47.7.2",
+        "@ckeditor/ckeditor5-widget": "47.7.2",
+        "@ckeditor/ckeditor5-word-count": "47.7.2"
       }
     },
     "node_modules/color-convert": {
@@ -2485,17 +2913,63 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/compress-commons": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.2.tgz",
+      "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "^0.2.13",
+        "crc32-stream": "^4.0.2",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.3.tgz",
+      "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^3.4.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -2510,6 +2984,12 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.3.5",
@@ -2528,9 +3008,9 @@
       }
     },
     "node_modules/decode-named-character-reference": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz",
-      "integrity": "sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
       "license": "MIT",
       "dependencies": {
         "character-entities": "^2.0.0"
@@ -2590,6 +3070,54 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/duplexer2/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/duplexer2/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/duplexer2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/es-toolkit": {
@@ -2757,20 +3285,22 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -2837,11 +3367,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/exceljs": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/exceljs/-/exceljs-4.4.0.tgz",
+      "integrity": "sha512-XctvKaEMaj1Ii9oDOqbW/6e1gXknSY4g/aLCDicOXqBE4M0nRWkUu0PTp++UPNzoFY12BNHMfs/VadKIS6llvg==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver": "^5.0.0",
+        "dayjs": "^1.8.34",
+        "fast-csv": "^4.3.1",
+        "jszip": "^3.10.1",
+        "readable-stream": "^3.6.0",
+        "saxes": "^5.0.1",
+        "tmp": "^0.2.0",
+        "unzipper": "^0.10.11",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
+    },
+    "node_modules/fast-csv": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/fast-csv/-/fast-csv-4.3.6.tgz",
+      "integrity": "sha512-2RNSpuwwsJGP0frGsOmTb9oUF+VkFSM4SyLTDgwf2ciHWTarN0lQTC+F2f/t5J9QjW+c65VFIAAu85GsvMIusw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fast-csv/format": "4.3.5",
+        "@fast-csv/parse": "4.3.6"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -2953,16 +3516,22 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
-      "dev": true
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -2970,12 +3539,42 @@
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/fstream/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
     "node_modules/fuzzysort": {
@@ -2989,7 +3588,6 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Glob versions prior to v9 are no longer supported",
-      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -3018,20 +3616,20 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -3073,6 +3671,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -3324,6 +3928,26 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
@@ -3332,6 +3956,12 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -3363,7 +3993,6 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -3372,8 +4001,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -3426,6 +4054,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3438,10 +4072,11 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -3467,6 +4102,48 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3474,6 +4151,48 @@
       "dev": true,
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/levn": {
@@ -3488,6 +4207,21 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/listenercount": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+      "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
+      "license": "ISC"
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -3504,11 +4238,90 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isfunction": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnil": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
+      "integrity": "sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isundefined": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
+      "integrity": "sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
+      "license": "MIT"
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -3570,9 +4383,9 @@
       }
     },
     "node_modules/mdast-util-from-markdown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
-      "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -4350,10 +5163,11 @@
       "license": "MIT"
     },
     "node_modules/micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
@@ -4363,12 +5177,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -4377,15 +5192,36 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -4393,6 +5229,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -4406,11 +5243,19 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -4462,6 +5307,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4487,7 +5338,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4511,16 +5361,18 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
-      "dev": true
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -4529,9 +5381,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.38",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
-      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -4547,10 +5399,11 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.2.0"
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -4564,6 +5417,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
     },
     "node_modules/property-information": {
       "version": "7.1.0",
@@ -4625,6 +5484,41 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/rehype-dom-parse": {
@@ -4797,12 +5691,13 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.18.0.tgz",
-      "integrity": "sha512-QmJz14PX3rzbJCN1SG4Xe/bAAX2a6NpCP8ab2vfu2GiUr8AQcr2nCV/oEO3yneFarB67zk8ShlIyWb2LGTb3Sg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.5"
+        "@types/estree": "1.0.8"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -4812,22 +5707,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.18.0",
-        "@rollup/rollup-android-arm64": "4.18.0",
-        "@rollup/rollup-darwin-arm64": "4.18.0",
-        "@rollup/rollup-darwin-x64": "4.18.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.18.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.18.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.18.0",
-        "@rollup/rollup-linux-arm64-musl": "4.18.0",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.18.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.18.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.18.0",
-        "@rollup/rollup-linux-x64-gnu": "4.18.0",
-        "@rollup/rollup-linux-x64-musl": "4.18.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.18.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.18.0",
-        "@rollup/rollup-win32-x64-msvc": "4.18.0",
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
         "fsevents": "~2.3.2"
       }
     },
@@ -4854,6 +5758,38 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -4873,6 +5809,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -4905,10 +5847,11 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
-      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4921,6 +5864,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/stringify-entities": {
@@ -4973,11 +5925,36 @@
         "node": ">=8"
       }
     },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -4989,6 +5966,15 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
+      "license": "MIT/X11",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/trim-lines": {
@@ -5171,6 +6157,54 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/unzipper": {
+      "version": "0.10.14",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
+      "integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
+      "license": "MIT",
+      "dependencies": {
+        "big-integer": "^1.6.17",
+        "binary": "~0.3.0",
+        "bluebird": "~3.4.1",
+        "buffer-indexof-polyfill": "~1.0.0",
+        "duplexer2": "~0.1.4",
+        "fstream": "^1.0.12",
+        "graceful-fs": "^4.2.2",
+        "listenercount": "~1.0.1",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "~1.0.4"
+      }
+    },
+    "node_modules/unzipper/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/unzipper/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/unzipper/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -5178,6 +6212,22 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vanilla-colorful": {
@@ -5215,14 +6265,15 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.3.2.tgz",
-      "integrity": "sha512-6lA7OBHBlXUxiJxbO5aAY2fsHHzDr1q7DvXYnyZycRs2Dz+dXBWuhpWHvmljTRTpQC2uvGmUFFkSHF2vGo90MA==",
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.21.3",
-        "postcss": "^8.4.38",
-        "rollup": "^4.13.0"
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -5241,6 +6292,7 @@
         "less": "*",
         "lightningcss": "^1.21.0",
         "sass": "*",
+        "sass-embedded": "*",
         "stylus": "*",
         "sugarss": "*",
         "terser": "^5.4.0"
@@ -5256,6 +6308,9 @@
           "optional": true
         },
         "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
           "optional": true
         },
         "stylus": {
@@ -5306,8 +6361,13 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
@@ -5319,6 +6379,41 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.1.tgz",
+      "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^3.0.4",
+        "compress-commons": "^4.1.2",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/zip-stream/node_modules/archiver-utils": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-3.0.4.tgz",
+      "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.2.3",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@ckeditor/ckeditor5-react": "^11.0.1",
     "ckeditor5": "^47.3.0",
+    "exceljs": "^4.4.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/src/App.css
+++ b/src/App.css
@@ -163,3 +163,60 @@
 .rich-text-preview .ck.ck-editor__editable {
     background-color: #fff !important;
 }
+
+.file-templates-description {
+    margin-top: 0;
+}
+
+.file-template-list {
+    list-style-type: none;
+    padding: 0;
+}
+
+.xlsx-template-panel {
+    margin-bottom: 1.5rem;
+    padding: 1rem;
+    border: 1px solid rgba(200, 200, 200, 0.2);
+    border-radius: 8px;
+    text-align: left;
+}
+
+.xlsx-template-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: flex-start;
+}
+
+.xlsx-template-header label {
+    font-weight: 600;
+}
+
+.xlsx-template-panel p {
+    margin: 0.25rem 0 0;
+}
+
+.xlsx-file-name-row {
+    margin-top: 1rem;
+}
+
+.xlsx-file-name-row input {
+    box-sizing: border-box;
+    width: 100%;
+}
+
+.xlsx-upload-actions {
+    margin-top: 1rem;
+}
+
+.xlsx-upload-message {
+    margin-top: 0.75rem;
+}
+
+.xlsx-upload-message.error {
+    color: #ff6b6b;
+}
+
+.xlsx-upload-message.success {
+    color: #4caf50;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,13 +14,19 @@ import { Header } from './components/Header'
 import { RichTextPair } from './components/RichTextPair'
 import { ToolsHeader } from './components/ToolsHeader'
 import { Environments } from './components/Environments'
+import { FileTemplates } from './components/FileTemplates'
+import { FileTemplateInterface } from './common/fileTemplate.interface'
 import { EnvironmentInterface } from './common/environment.interface'
 import {
+    createDefaultFileTemplate,
     getCacheEnvironments,
+    getCacheFileTemplates,
     setEnvironmentsToCache,
+    setFileTemplatesToCache,
     getCacheCurrentEnvironmentId,
     setCacheCurrentEnvironmentId,
 } from './services/cache.service'
+import { convertTemplate } from './services/template.service'
 
 type TemplateMode = 'edit' | 'preview'
 
@@ -48,6 +54,9 @@ function App() {
     const [currentEnvironmentId, setCurrentEnvironmentId] = useState<string>(
         getCacheCurrentEnvironmentId(),
     )
+    const [fileTemplates, setFileTemplates] = useState<FileTemplateInterface[]>(
+        getCacheFileTemplates(),
+    )
     const [draggedIndex, setDraggedIndex] = useState<number>(-1)
     const [draggedOverIndex, setDraggedOverIndex] = useState<number>(-1)
 
@@ -68,6 +77,10 @@ function App() {
     useEffect(() => {
         setCacheCurrentEnvironmentId(currentEnvironmentId)
     }, [currentEnvironmentId])
+
+    useEffect(() => {
+        setFileTemplatesToCache(fileTemplates)
+    }, [fileTemplates])
 
     // Functions for Variables
     const addVariable = (
@@ -126,87 +139,13 @@ function App() {
         SetTextResults(newTexts)
     }
 
-    const convert = (text: string) => {
-        // Resolve environment variables first
-        const currentEnv = environments.find(
-            (e) => e.id === currentEnvironmentId,
-        )
-        const resolvedVars = vars.map((v) => {
-            let newValue = v.value
-            // Only modify string values for now, or handle arrays if needed.
-            // Assuming environment variables are simple replacements.
-            if (currentEnv) {
-                const replaceInString = (str: string) => {
-                    let s = str
-                    for (const envVal of currentEnv.values) {
-                        s = s.replace(
-                            new RegExp(`{{${envVal.key}}}`, 'g'),
-                            envVal.value,
-                        )
-                    }
-                    return s
-                }
+    const getTemplateContext = () => ({
+        variables: vars,
+        environments,
+        currentEnvironmentId,
+    })
 
-                if (typeof newValue === 'string') {
-                    newValue = replaceInString(newValue)
-                } else if (Array.isArray(newValue)) {
-                    newValue = newValue.map(replaceInString)
-                }
-            }
-            return { ...v, value: newValue }
-        })
-
-        // For single variables
-        for (const v of resolvedVars) {
-            text = text.replace(
-                new RegExp(`{{${v.key}}}`, 'g'),
-                String(v.value),
-            )
-        }
-        // Identifies all iterative matches
-        const iterableSections = text.match(/:::(.*?):::/g)
-        console.log('Found iterable sections')
-        console.log(iterableSections)
-        if (iterableSections) {
-            // Prepares iterations for each match
-            for (let i = 0; i < iterableSections.length; i++) {
-                const iterableSection = iterableSections[i]
-                const resulting = []
-                for (const v of resolvedVars) {
-                    if (
-                        Array.isArray(v.value) &&
-                        iterableSection.includes(`{{${v.key}.label}}`)
-                    ) {
-                        const newSectionWithAllVarsReplaced = []
-                        for (let j = 0; j < v.value.length; j++) {
-                            let newSubForEachVar = iterableSection.slice(3, -3)
-                            newSubForEachVar = newSubForEachVar.replace(
-                                new RegExp(`{{${v.key}.label}}`, 'g'),
-                                String(v.label[j]),
-                            )
-                            newSubForEachVar = newSubForEachVar.replace(
-                                new RegExp(`{{${v.key}.value}}`, 'g'),
-                                String(v.value[j]),
-                            )
-                            newSectionWithAllVarsReplaced.push(newSubForEachVar)
-                        }
-                        // resulting.push(newSectionWithAllVarsReplaced.join('\n'))
-                        resulting.push(
-                            newSectionWithAllVarsReplaced.join('<br/>'),
-                        )
-                    }
-                }
-                if (resulting.length > 0) {
-                    // text = text.replace(iterableSection, resulting.join('\n'))
-                    text = text.replace(
-                        iterableSection,
-                        resulting.join('<br/>'),
-                    )
-                }
-            }
-        }
-        return text
-    }
+    const convert = (text: string) => convertTemplate(text, getTemplateContext())
 
     const convertOne = (index: number) => {
         const texts = textResults.map((textResult, i) => {
@@ -252,6 +191,29 @@ function App() {
         setTemplateModes(templateModes.filter((_, i) => i !== index))
     }
 
+    const addFileTemplate = () => {
+        setFileTemplates([...fileTemplates, createDefaultFileTemplate()])
+    }
+
+    const updateFileTemplate = (
+        id: string,
+        update: Partial<FileTemplateInterface>,
+    ) => {
+        setFileTemplates(
+            fileTemplates.map((fileTemplate) =>
+                fileTemplate.id === id
+                    ? { ...fileTemplate, ...update }
+                    : fileTemplate,
+            ),
+        )
+    }
+
+    const deleteFileTemplate = (id: string) => {
+        setFileTemplates(
+            fileTemplates.filter((fileTemplate) => fileTemplate.id !== id),
+        )
+    }
+
     // Functions for Drag and Drop
 
     const updatePositionOnSuccessDrag = (
@@ -267,6 +229,7 @@ function App() {
 
     const variablesSectionRef = useRef<HTMLDivElement>(null)
     const textsSectionRef = useRef<HTMLDivElement>(null)
+    const fileTemplatesSectionRef = useRef<HTMLDivElement>(null)
     const environmentsSectionRef = useRef<HTMLDivElement>(null)
 
     const scrollToVariables = () => {
@@ -293,6 +256,18 @@ function App() {
         }
     }
 
+    const scrollToFileTemplates = () => {
+        if (fileTemplatesSectionRef.current) {
+            const yOffset = -120 // Accounts for fixed headers
+            const element = fileTemplatesSectionRef.current
+            const y =
+                element.getBoundingClientRect().top +
+                window.pageYOffset +
+                yOffset
+            window.scrollTo({ top: y, behavior: 'smooth' })
+        }
+    }
+
     const scrollToEnvironments = () => {
         if (environmentsSectionRef.current) {
             const yOffset = -120 // Accounts for fixed headers
@@ -311,6 +286,7 @@ function App() {
             <ToolsHeader
                 onScrollToVariables={scrollToVariables}
                 onScrollToTemplates={scrollToTexts}
+                onScrollToFileTemplates={scrollToFileTemplates}
                 onScrollToEnvironments={scrollToEnvironments}
                 onConvert={convertAll}
                 environments={environments}
@@ -449,6 +425,18 @@ function App() {
                     })}
                 </ul>
                 <button onClick={addText}>Add Text</button>
+            </section>
+
+            <section ref={fileTemplatesSectionRef}>
+                <FileTemplates
+                    fileTemplates={fileTemplates}
+                    variables={vars}
+                    environments={environments}
+                    currentEnvironmentId={currentEnvironmentId}
+                    onAddFileTemplate={addFileTemplate}
+                    onUpdateFileTemplate={updateFileTemplate}
+                    onDeleteFileTemplate={deleteFileTemplate}
+                />
             </section>
         </>
     )

--- a/src/common/fileTemplate.interface.ts
+++ b/src/common/fileTemplate.interface.ts
@@ -1,0 +1,4 @@
+export interface FileTemplateInterface {
+    id: string
+    outputFileNameTemplate: string
+}

--- a/src/common/saveDocument.interface.ts
+++ b/src/common/saveDocument.interface.ts
@@ -1,9 +1,11 @@
 import { TextResultInterface } from './textResult.interface'
 import { VariableInterface } from './variable.interface'
 import { EnvironmentInterface } from './environment.interface'
+import { FileTemplateInterface } from './fileTemplate.interface'
 
 export interface SaveDocumentInterface {
     variables: VariableInterface[]
     textResults: TextResultInterface[]
     environments: EnvironmentInterface[]
+    fileTemplates: FileTemplateInterface[]
 }

--- a/src/components/FileTemplates.tsx
+++ b/src/components/FileTemplates.tsx
@@ -1,0 +1,60 @@
+import { EnvironmentInterface } from '../common/environment.interface'
+import { FileTemplateInterface } from '../common/fileTemplate.interface'
+import { VariableInterface } from '../common/variable.interface'
+import { XlsxTemplateUploader } from './XlsxTemplateUploader'
+
+interface FileTemplatesProps {
+    fileTemplates: FileTemplateInterface[]
+    variables: VariableInterface[]
+    environments: EnvironmentInterface[]
+    currentEnvironmentId: string
+    onAddFileTemplate: () => void
+    onUpdateFileTemplate: (
+        id: string,
+        update: Partial<FileTemplateInterface>,
+    ) => void
+    onDeleteFileTemplate: (id: string) => void
+}
+
+export const FileTemplates = ({
+    fileTemplates,
+    variables,
+    environments,
+    currentEnvironmentId,
+    onAddFileTemplate,
+    onUpdateFileTemplate,
+    onDeleteFileTemplate,
+}: FileTemplatesProps) => {
+    return (
+        <>
+            <h1>File Templates</h1>
+            <p className="file-templates-description">
+                Upload XLSX files with placeholders and choose the converted
+                file name.
+            </p>
+            {fileTemplates.length > 0 && (
+                <ul className="file-template-list">
+                    {fileTemplates.map((fileTemplate) => (
+                        <li key={fileTemplate.id}>
+                            <XlsxTemplateUploader
+                                fileTemplate={fileTemplate}
+                                variables={variables}
+                                environments={environments}
+                                currentEnvironmentId={currentEnvironmentId}
+                                onOutputFileNameTemplateChange={(value) =>
+                                    onUpdateFileTemplate(fileTemplate.id, {
+                                        outputFileNameTemplate: value,
+                                    })
+                                }
+                                onDelete={() =>
+                                    onDeleteFileTemplate(fileTemplate.id)
+                                }
+                            />
+                        </li>
+                    ))}
+                </ul>
+            )}
+            <button onClick={onAddFileTemplate}>Add file template</button>
+        </>
+    )
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,7 +1,8 @@
-import { useRef, useState } from 'react'
+import { ChangeEvent, useRef, useState } from 'react'
 import { SaveDocumentInterface } from '../common/saveDocument.interface'
 import {
     getCacheToDownload,
+    getDefaultFileTemplates,
     loadToCacheFromFile,
 } from '../services/cache.service'
 import { downloadFile } from '../services/files.service'
@@ -16,9 +17,14 @@ export const Header = () => {
         downloadFile(currentCache)
     }
 
-    const openFile = (e: any) => {
+    const openFile = (e: ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0]
+        if (!file) {
+            return
+        }
+
         const fileReader = new FileReader()
-        fileReader.readAsText(e.target.files[0], 'UTF-8')
+        fileReader.readAsText(file, 'UTF-8')
         fileReader.onload = (e) => {
             if (e.target?.result && typeof e.target.result == 'string') {
                 const jsonData = JSON.parse(e.target?.result)
@@ -27,6 +33,9 @@ export const Header = () => {
                         variables: jsonData.variables,
                         textResults: jsonData.textResults,
                         environments: jsonData.environments || [],
+                        fileTemplates: Array.isArray(jsonData.fileTemplates)
+                            ? jsonData.fileTemplates
+                            : getDefaultFileTemplates(),
                     }
                     loadToCacheFromFile(savedDocument)
                 }

--- a/src/components/InstructionsModal.tsx
+++ b/src/components/InstructionsModal.tsx
@@ -20,7 +20,8 @@ export const InstructionsModal: React.FC<InstructionsModalProps> = ({
                 <h3>Instructions</h3>
                 <p>
                     This tool allows you to generate texts uring variables and
-                    templates where those variables will be replaced.
+                    templates where those variables will be replaced. It can
+                    also convert XLSX files using the same variables.
                 </p>
                 <h3>Variables</h3>
                 <p>In this section you can create:</p>
@@ -87,6 +88,27 @@ export const InstructionsModal: React.FC<InstructionsModalProps> = ({
                 <code>color of banana is yellow</code>
                 <br />
                 <code>color of orange is orange</code>
+                <h3>File Templates</h3>
+                <p>
+                    File Templates let you upload an XLSX file and download a
+                    converted copy. The file is processed only in your browser
+                    and is not stored in the saved JSON document.
+                </p>
+                <p>
+                    Add one or more file template rows. Each row has a{' '}
+                    <strong>Download file name</strong> input and an{' '}
+                    <strong>Upload XLSX</strong> button.
+                </p>
+                <p>
+                    The download file name can use variables and the active
+                    environment, for example:
+                </p>
+                <code>{'report-{{clientName}}-{{environmentName}}'}</code>
+                <p>
+                    The spreadsheet can use simple placeholders like{' '}
+                    <code>{'{{name}}'}</code> inside text cells. List variable
+                    expansion is only supported in rich text templates.
+                </p>
             </div>
         </div>
     )

--- a/src/components/RichText.tsx
+++ b/src/components/RichText.tsx
@@ -63,7 +63,7 @@ export const RichText = (props: RichTextProps) => {
             'RichText of type ' + props.type + ' updated: props.content',
             props.content,
         )
-    }, [props.content])
+    }, [props.content, props.type])
 
     return (
         <section

--- a/src/components/ToolsHeader.tsx
+++ b/src/components/ToolsHeader.tsx
@@ -4,6 +4,7 @@ import { EnvironmentInterface } from '../common/environment.interface'
 interface ToolsHeaderProps {
     onScrollToVariables: () => void
     onScrollToTemplates: () => void
+    onScrollToFileTemplates: () => void
     onScrollToEnvironments: () => void
     onConvert: () => void
     environments: EnvironmentInterface[]
@@ -14,6 +15,7 @@ interface ToolsHeaderProps {
 export const ToolsHeader: React.FC<ToolsHeaderProps> = ({
     onScrollToVariables,
     onScrollToTemplates,
+    onScrollToFileTemplates,
     onScrollToEnvironments,
     onConvert,
     environments,
@@ -40,6 +42,9 @@ export const ToolsHeader: React.FC<ToolsHeaderProps> = ({
             <button onClick={onScrollToEnvironments}>See environments</button>
             <button onClick={onScrollToVariables}>See variables</button>
             <button onClick={onScrollToTemplates}>See templates</button>
+            <button onClick={onScrollToFileTemplates}>
+                See file templates
+            </button>
 
             <div
                 style={{

--- a/src/components/Variable.tsx
+++ b/src/components/Variable.tsx
@@ -24,38 +24,38 @@ export const Variable = (props: VariableProps) => {
     }
 
     const updateListItemValue = (index: number, value: string) => {
-        let newList = [...(props.info.value as Array<string>)]
+        const newList = [...(props.info.value as Array<string>)]
         newList[index] = value
         props.onValueChange(newList)
     }
 
     const updateListItemLabel = (index: number, label: string) => {
-        let newList = [...(props.info.label as Array<string>)]
+        const newList = [...(props.info.label as Array<string>)]
         newList[index] = label
         props.onLabelChange(newList)
     }
 
     const addListItem = () => {
-        let newList = [...(props.info.value as Array<string>)]
+        const newList = [...(props.info.value as Array<string>)]
         newList.push('')
         props.onValueChange(newList)
-        let newLabel = [...(props.info.label as Array<string>)]
+        const newLabel = [...(props.info.label as Array<string>)]
         newLabel.push('')
         props.onLabelChange(newLabel)
     }
 
     const clearListItem = (index: number) => {
-        let newList = [...(props.info.value as Array<string>)]
+        const newList = [...(props.info.value as Array<string>)]
         newList[index] = ''
         props.onValueChange(newList)
     }
 
     const deleteListItem = (index: number) => {
         if (window.confirm("Are you sure you want to delete this item?")) {
-            let newList = [...(props.info.value as Array<string>)]
+            const newList = [...(props.info.value as Array<string>)]
             newList.splice(index, 1)
             props.onValueChange(newList)
-            let newLabel = [...(props.info.label as Array<string>)]
+            const newLabel = [...(props.info.label as Array<string>)]
             newLabel.splice(index, 1)
             props.onLabelChange(newLabel)
         }
@@ -63,14 +63,14 @@ export const Variable = (props: VariableProps) => {
 
     // Functions for Drag and Drop
     const updatePositionOnSuccessDrag = (draggedIndex: number, draggedOverIndex: number) => {
-        let newVars = [...(props.info.value as Array<string>)]
-        let draggedItem = newVars[draggedIndex]
+        const newVars = [...(props.info.value as Array<string>)]
+        const draggedItem = newVars[draggedIndex]
         newVars.splice(draggedIndex, 1)
         newVars.splice(draggedOverIndex, 0, draggedItem)
         props.onValueChange(newVars)
 
-        let newLabel = [...(props.info.label as Array<string>)]
-        let draggedLabel = newLabel[draggedIndex]
+        const newLabel = [...(props.info.label as Array<string>)]
+        const draggedLabel = newLabel[draggedIndex]
         newLabel.splice(draggedIndex, 1)
         newLabel.splice(draggedOverIndex, 0, draggedLabel)
         props.onLabelChange(newLabel)

--- a/src/components/XlsxTemplateUploader.tsx
+++ b/src/components/XlsxTemplateUploader.tsx
@@ -1,0 +1,111 @@
+import { ChangeEvent, useRef, useState } from 'react'
+import { EnvironmentInterface } from '../common/environment.interface'
+import { FileTemplateInterface } from '../common/fileTemplate.interface'
+import { VariableInterface } from '../common/variable.interface'
+import { processXlsxFile } from '../services/xlsx.service'
+
+interface XlsxTemplateUploaderProps {
+    fileTemplate: FileTemplateInterface
+    variables: VariableInterface[]
+    environments: EnvironmentInterface[]
+    currentEnvironmentId: string
+    onOutputFileNameTemplateChange: (value: string) => void
+    onDelete: () => void
+}
+
+type UploadStatus = 'idle' | 'processing' | 'success' | 'error'
+
+export const XlsxTemplateUploader = ({
+    fileTemplate,
+    variables,
+    environments,
+    currentEnvironmentId,
+    onOutputFileNameTemplateChange,
+    onDelete,
+}: XlsxTemplateUploaderProps) => {
+    const inputRef = useRef<HTMLInputElement>(null)
+    const [status, setStatus] = useState<UploadStatus>('idle')
+    const [message, setMessage] = useState('')
+
+    const handleFileChange = async (e: ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0]
+        if (!file) {
+            return
+        }
+
+        if (!file.name.toLowerCase().endsWith('.xlsx')) {
+            setStatus('error')
+            setMessage('Upload an .xlsx file.')
+            e.target.value = ''
+            return
+        }
+
+        try {
+            setStatus('processing')
+            setMessage('Processing file...')
+            const result = await processXlsxFile(file, {
+                variables,
+                environments,
+                currentEnvironmentId,
+            }, fileTemplate.outputFileNameTemplate)
+            setStatus('success')
+            setMessage(
+                `Downloaded ${result.fileName}. Replaced ${result.replacedCells} cell${result.replacedCells === 1 ? '' : 's'}.`,
+            )
+        } catch (error) {
+            setStatus('error')
+            setMessage(
+                error instanceof Error
+                    ? error.message
+                    : 'The XLSX file could not be processed.',
+            )
+        } finally {
+            e.target.value = ''
+        }
+    }
+
+    return (
+        <div className="xlsx-template-panel">
+            <div className="xlsx-template-header">
+                <div>
+                    <label htmlFor={`file-template-${fileTemplate.id}`}>
+                        Download file name
+                    </label>
+                    <p>
+                        Use variables like {'{{name}}'} or {'{{environmentName}}'}.
+                    </p>
+                </div>
+                <button onClick={onDelete}>Remove</button>
+            </div>
+            <div className="xlsx-file-name-row">
+                <input
+                    id={`file-template-${fileTemplate.id}`}
+                    value={fileTemplate.outputFileNameTemplate}
+                    onChange={(e) =>
+                        onOutputFileNameTemplateChange(e.target.value)
+                    }
+                    placeholder="report-{{client}}"
+                />
+            </div>
+            <div className="xlsx-upload-actions">
+                <button
+                    onClick={() => inputRef.current?.click()}
+                    disabled={status === 'processing'}
+                >
+                    {status === 'processing' ? 'Processing...' : 'Upload XLSX'}
+                </button>
+                <input
+                    ref={inputRef}
+                    type="file"
+                    accept=".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+                    onChange={handleFileChange}
+                    disabled={status === 'processing'}
+                    style={{ display: 'none' }}
+                />
+            </div>
+            {message && (
+                <p className={`xlsx-upload-message ${status}`}>{message}</p>
+            )}
+        </div>
+    )
+}

--- a/src/services/cache.service.ts
+++ b/src/services/cache.service.ts
@@ -1,7 +1,24 @@
 import { EnvironmentInterface } from '../common/environment.interface'
+import { FileTemplateInterface } from '../common/fileTemplate.interface'
 import { SaveDocumentInterface } from '../common/saveDocument.interface'
 import { TextResultInterface } from '../common/textResult.interface'
 import { VariableInterface } from '../common/variable.interface'
+
+const createId = () => {
+    return (
+        globalThis.crypto?.randomUUID?.() ||
+        `${Date.now()}-${Math.random().toString(36).slice(2)}`
+    )
+}
+
+export const createDefaultFileTemplate = (): FileTemplateInterface => ({
+    id: createId(),
+    outputFileNameTemplate: '',
+})
+
+export const getDefaultFileTemplates = (): FileTemplateInterface[] => [
+    createDefaultFileTemplate(),
+]
 
 export const getCacheVariables = (): VariableInterface[] => {
     const variablesString: string | null = localStorage.getItem('variables')
@@ -32,11 +49,25 @@ export const getCacheTextResults = (): TextResultInterface[] => {
     return JSON.parse(textResultsString)
 }
 
+export const getCacheFileTemplates = (): FileTemplateInterface[] => {
+    const fileTemplatesString: string | null =
+        localStorage.getItem('fileTemplates')
+    if (!fileTemplatesString) {
+        return getDefaultFileTemplates()
+    }
+
+    const fileTemplates = JSON.parse(fileTemplatesString)
+    return Array.isArray(fileTemplates)
+        ? fileTemplates
+        : getDefaultFileTemplates()
+}
+
 export const getCacheToDownload = (): SaveDocumentInterface => {
     return {
         variables: getCacheVariables(),
         textResults: getCacheTextResults(),
         environments: getCacheEnvironments(),
+        fileTemplates: getCacheFileTemplates(),
     }
 }
 
@@ -46,6 +77,9 @@ export const loadToCacheFromFile = (
     setVariablesToCache(savedDocument.variables)
     setTextResultsCache(savedDocument.textResults)
     setEnvironmentsToCache(savedDocument.environments || [])
+    setFileTemplatesToCache(
+        savedDocument.fileTemplates || getDefaultFileTemplates(),
+    )
     window.location.reload()
 }
 
@@ -61,6 +95,12 @@ export const setEnvironmentsToCache = (
     environments: EnvironmentInterface[],
 ) => {
     localStorage.setItem('environments', JSON.stringify(environments))
+}
+
+export const setFileTemplatesToCache = (
+    fileTemplates: FileTemplateInterface[],
+) => {
+    localStorage.setItem('fileTemplates', JSON.stringify(fileTemplates))
 }
 
 export const setCacheCurrentEnvironmentId = (id: string) => {

--- a/src/services/files.service.ts
+++ b/src/services/files.service.ts
@@ -1,17 +1,21 @@
 import { SaveDocumentInterface } from "../common/saveDocument.interface";
 import { SAVE_DOCUMENT_EXTENSION } from "../settings";
 
-export const downloadFile = (saveDocument: SaveDocumentInterface):void => {
-    const jsonString = JSON.stringify(saveDocument)
-    const blob = new Blob([jsonString], {type: 'application/json'})
+export const downloadBlob = (blob: Blob, fileName: string): void => {
     const url = URL.createObjectURL(blob)
     const link = document.createElement('a')
-    
-    link.href = URL.createObjectURL(blob)
-    link.download = `save_document${SAVE_DOCUMENT_EXTENSION}`
+
+    link.href = url
+    link.download = fileName
     document.body.appendChild(link)
     link.click()
 
     document.body.removeChild(link)
     URL.revokeObjectURL(url)
+}
+
+export const downloadFile = (saveDocument: SaveDocumentInterface):void => {
+    const jsonString = JSON.stringify(saveDocument)
+    const blob = new Blob([jsonString], {type: 'application/json'})
+    downloadBlob(blob, `save_document${SAVE_DOCUMENT_EXTENSION}`)
 }

--- a/src/services/template.service.ts
+++ b/src/services/template.service.ts
@@ -1,0 +1,131 @@
+import { EnvironmentInterface } from '../common/environment.interface'
+import { VariableInterface } from '../common/variable.interface'
+
+export interface TemplateConversionContext {
+    variables: VariableInterface[]
+    environments: EnvironmentInterface[]
+    currentEnvironmentId: string
+}
+
+const escapeRegExp = (value: string) => {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+const replaceToken = (text: string, key: string, value: string) => {
+    if (!key) {
+        return text
+    }
+
+    return text.replace(new RegExp(`{{${escapeRegExp(key)}}}`, 'g'), value)
+}
+
+export const resolveVariables = ({
+    variables,
+    environments,
+    currentEnvironmentId,
+}: TemplateConversionContext) => {
+    const currentEnv = environments.find((e) => e.id === currentEnvironmentId)
+
+    return variables.map((v) => {
+        let newValue = v.value
+
+        if (currentEnv) {
+            const replaceInString = (str: string) => {
+                let s = str
+                for (const envVal of currentEnv.values) {
+                    s = replaceToken(s, envVal.key, envVal.value)
+                }
+                return s
+            }
+
+            if (typeof newValue === 'string') {
+                newValue = replaceInString(newValue)
+            } else if (Array.isArray(newValue)) {
+                newValue = newValue.map(replaceInString)
+            }
+        }
+
+        return { ...v, value: newValue }
+    })
+}
+
+export const convertTemplate = (
+    text: string,
+    context: TemplateConversionContext,
+) => {
+    const resolvedVars = resolveVariables(context)
+
+    for (const v of resolvedVars) {
+        text = replaceToken(text, v.key, String(v.value))
+    }
+
+    const iterableSections = text.match(/:::(.*?):::/g)
+    if (iterableSections) {
+        for (let i = 0; i < iterableSections.length; i++) {
+            const iterableSection = iterableSections[i]
+            const resulting = []
+            for (const v of resolvedVars) {
+                if (
+                    Array.isArray(v.value) &&
+                    iterableSection.includes(`{{${v.key}.label}}`)
+                ) {
+                    const newSectionWithAllVarsReplaced = []
+                    for (let j = 0; j < v.value.length; j++) {
+                        let newSubForEachVar = iterableSection.slice(3, -3)
+                        newSubForEachVar = newSubForEachVar.replace(
+                            new RegExp(
+                                `{{${escapeRegExp(v.key)}\\.label}}`,
+                                'g',
+                            ),
+                            String(v.label[j]),
+                        )
+                        newSubForEachVar = newSubForEachVar.replace(
+                            new RegExp(
+                                `{{${escapeRegExp(v.key)}\\.value}}`,
+                                'g',
+                            ),
+                            String(v.value[j]),
+                        )
+                        newSectionWithAllVarsReplaced.push(newSubForEachVar)
+                    }
+                    resulting.push(newSectionWithAllVarsReplaced.join('<br/>'))
+                }
+            }
+            if (resulting.length > 0) {
+                text = text.replace(iterableSection, resulting.join('<br/>'))
+            }
+        }
+    }
+
+    return text
+}
+
+export const replaceSimpleVariables = (
+    text: string,
+    context: TemplateConversionContext,
+) => {
+    let converted = text
+    const resolvedVars = resolveVariables(context)
+
+    for (const v of resolvedVars) {
+        if (typeof v.value === 'string') {
+            converted = replaceToken(converted, v.key, v.value)
+        }
+    }
+
+    return converted
+}
+
+export const replaceFileTemplateVariables = (
+    text: string,
+    context: TemplateConversionContext,
+) => {
+    const currentEnv = context.environments.find(
+        (e) => e.id === context.currentEnvironmentId,
+    )
+
+    return replaceSimpleVariables(
+        replaceToken(text, 'environmentName', currentEnv?.name || ''),
+        context,
+    )
+}

--- a/src/services/xlsx.service.ts
+++ b/src/services/xlsx.service.ts
@@ -1,0 +1,82 @@
+import {
+    TemplateConversionContext,
+    replaceFileTemplateVariables,
+    replaceSimpleVariables,
+} from './template.service'
+import { downloadBlob } from './files.service'
+
+export interface ProcessXlsxResult {
+    fileName: string
+    replacedCells: number
+}
+
+const getConvertedFileName = (fileName: string) => {
+    return fileName.replace(/\.xlsx$/i, '') + '-converted.xlsx'
+}
+
+const sanitizeFileName = (fileName: string) => {
+    return fileName.replace(/[\\/:*?"<>|]/g, '-').trim()
+}
+
+const getOutputFileName = (
+    originalFileName: string,
+    outputFileNameTemplate: string,
+    context: TemplateConversionContext,
+) => {
+    const resolvedName = sanitizeFileName(
+        replaceFileTemplateVariables(outputFileNameTemplate, context),
+    )
+
+    if (!resolvedName) {
+        return getConvertedFileName(originalFileName)
+    }
+
+    return resolvedName.toLowerCase().endsWith('.xlsx')
+        ? resolvedName
+        : `${resolvedName}.xlsx`
+}
+
+export const processXlsxFile = async (
+    file: File,
+    context: TemplateConversionContext,
+    outputFileNameTemplate: string,
+): Promise<ProcessXlsxResult> => {
+    const ExcelJS = await import('exceljs')
+    const workbook = new ExcelJS.Workbook()
+    await workbook.xlsx.load(await file.arrayBuffer())
+    let replacedCells = 0
+
+    workbook.eachSheet((worksheet) => {
+        worksheet.eachRow((row) => {
+            row.eachCell((cell) => {
+                if (typeof cell.value !== 'string') {
+                    return
+                }
+
+                const converted = replaceSimpleVariables(cell.value, context)
+                if (converted !== cell.value) {
+                    cell.value = converted
+                    replacedCells++
+                }
+            })
+        })
+    })
+
+    const output = await workbook.xlsx.writeBuffer()
+    const fileName = getOutputFileName(
+        file.name,
+        outputFileNameTemplate,
+        context,
+    )
+    downloadBlob(
+        new Blob([output], {
+            type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        }),
+        fileName,
+    )
+
+    return {
+        fileName,
+        replacedCells,
+    }
+}


### PR DESCRIPTION
## Summary

Adds a dedicated File Templates workflow for client-side XLSX conversion.

Users can now create one or more file-template rows, define a download filename template, upload an `.xlsx` file, and download a converted workbook. The uploaded workbook is processed entirely in the browser and is not stored in saved JSON or localStorage.

## What Changed

- Added a separate **File Templates** section and header navigation button.
- Added multiple file-template rows with add/remove behavior.
- Added a persisted `fileTemplates` saved-document field containing output filename templates.
- Added backward compatibility for older saved JSON files that do not include `fileTemplates`.
- Added XLSX conversion with lazy-loaded `exceljs`.
- Extracted shared template conversion rules so rich text templates and file templates use the same variable/environment resolution.
- Added filename template support with variables and `{{environmentName}}`.
- Sanitized invalid filename characters and ensured `.xlsx` output.
- Updated README, architecture docs, and in-app instructions.

## Behavior Notes

- XLSX cell replacement currently supports simple placeholders like `{{name}}` in text cells across all worksheets.
- Filename templates can use app variables and `{{environmentName}}`.
- Empty filename templates fall back to `<original-name>-converted.xlsx`.
- Uploaded XLSX files are never persisted.
- List-variable row expansion remains supported only in rich text templates, not XLSX files.

## Validation

- `npm run lint`
- `npm run build`

Build passes with the existing large chunk warning from the editor/ExcelJS bundle.
